### PR TITLE
fix: Windows 환경에서도 gradlew가 문제 없도록 개선

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Gradle wrapper must always use LF
+gradlew text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+
+# Windows batch files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+## Java files
+*.java text eol=lf


### PR DESCRIPTION
## 🍀 이슈 번호
- #15

---

## ✅ 작업 사항

- [x] .gitattributes 를 추가하여, gradlew의 윈도우즈 환경에서 줄바꿈 이슈 개선

