### PR TITLE
fix: health check 접근 차단 개선

### DIFF
--- a/src/main/java/com/project/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/common/security/filter/JwtAuthenticationFilter.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
-import static com.project.common.util.WebSecurityUrl.READ_ONLY_PUBLIC_ENDPOINTS;
-import static com.project.common.util.WebSecurityUrl.HEALTH_CHECK_ENDPOINT;
-import static com.project.common.util.WebSecurityUrl.ANONYMOUS_ENDPOINTS;
+import static com.project.common.util.WebSecurityUrl.getHealthCheckEndpoints;
+import static com.project.common.util.WebSecurityUrl.getReadOnlyPublicEndpoints;
+import static com.project.common.util.WebSecurityUrl.getAnonymousEndpoints;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -43,8 +43,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected static final AntPathMatcher MATCHER = new AntPathMatcher();
 
     protected static final String[] PUBLIC_ENDPOINTS = Stream.of(
-            HEALTH_CHECK_ENDPOINT,
-            READ_ONLY_PUBLIC_ENDPOINTS
+            getHealthCheckEndpoints(),
+            getReadOnlyPublicEndpoints()
     ).flatMap(Arrays::stream).toArray(String[]::new);
 
 
@@ -75,14 +75,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
 
         return matches(uri, PUBLIC_ENDPOINTS)   // 완전 공개 API
-                || matches(uri, ANONYMOUS_ENDPOINTS); // 토큰 없어도 허용되는 API
+                || matches(uri, getAnonymousEndpoints()); // 토큰 없어도 허용되는 API
     }
 
     private boolean isAnonymousRequest(HttpServletRequest request) {
         String uri = request.getRequestURI();
         boolean headerMissing = request.getHeader(HttpHeaders.AUTHORIZATION) == null;
 
-        return headerMissing && matches(uri, ANONYMOUS_ENDPOINTS);
+        return headerMissing && matches(uri, getAnonymousEndpoints());
     }
 
     private String resolveAccessToken(

--- a/src/main/java/com/project/common/util/WebSecurityUrl.java
+++ b/src/main/java/com/project/common/util/WebSecurityUrl.java
@@ -6,10 +6,21 @@ public class WebSecurityUrl {
         throw new IllegalStateException("Utility class");
     }
 
-    public static final String[] HEALTH_CHECK_ENDPOINT = {"/health"};
-    public static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico"};
     public static final String LOGIN_ENDPOINT = "/api/oauth/login/**";
     public static final String REISSUE_ENDPOINT = "/api/oauth/reissue";
+    private static final String[] HEALTH_CHECK_ENDPOINTS = {"/health", "/actuator/health"};
+    private static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico"};
+    private static final String[] ANONYMOUS_ENDPOINTS = {LOGIN_ENDPOINT};
 
-    public static final String[] ANONYMOUS_ENDPOINTS = {LOGIN_ENDPOINT};
+    public static String[] getHealthCheckEndpoints() {
+        return HEALTH_CHECK_ENDPOINTS.clone();
+    }
+
+    public static String[] getReadOnlyPublicEndpoints() {
+        return READ_ONLY_PUBLIC_ENDPOINTS.clone();
+    }
+
+    public static String[] getAnonymousEndpoints() {
+        return ANONYMOUS_ENDPOINTS.clone();
+    }
 }

--- a/src/main/java/com/project/config/security/SecurityConfig.java
+++ b/src/main/java/com/project/config/security/SecurityConfig.java
@@ -16,11 +16,10 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import static com.project.common.util.WebSecurityUrl.getReadOnlyPublicEndpoints;
+import static com.project.common.util.WebSecurityUrl.getHealthCheckEndpoints;
 import static com.project.common.util.WebSecurityUrl.LOGIN_ENDPOINT;
-import static com.project.common.util.WebSecurityUrl.READ_ONLY_PUBLIC_ENDPOINTS;
 import static com.project.common.util.WebSecurityUrl.REISSUE_ENDPOINT;
-import static com.project.common.util.WebSecurityUrl.HEALTH_CHECK_ENDPOINT;
-
 
 @Configuration
 @EnableWebSecurity
@@ -51,11 +50,10 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, READ_ONLY_PUBLIC_ENDPOINTS).permitAll()
-                        .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, getReadOnlyPublicEndpoints()).permitAll()
+                        .requestMatchers(getHealthCheckEndpoints()).permitAll()
                         .requestMatchers(LOGIN_ENDPOINT).permitAll()
                         .requestMatchers(REISSUE_ENDPOINT).permitAll()
-                        .requestMatchers(HEALTH_CHECK_ENDPOINT).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 🍀 이슈 번호

- #19 

---

## ✅ 작업 사항

  - [x] WebSecurityUrl의 HEALTH_CHECK_ENDPOINT에 /actuator/health 추가
  - [x] SecurityConfig에서 중복된 actuator permitAll() 제거
  - [x] JWT 필터가 /actuator/health를 차단하여 ECS 헬스체크 실패하던 문제 해결
