### PR TITLE
feat: 마이페이지 조회 API 구현 및 코드 리팩토링

### DIFF
--- a/src/main/java/com/project/controller/UserController.java
+++ b/src/main/java/com/project/controller/UserController.java
@@ -5,6 +5,8 @@ import com.project.common.dto.ApiResponse;
 import com.project.common.security.SecurityUserDetails;
 import com.project.dto.request.SignUpRequest;
 import com.project.dto.response.BojCheckResponse;
+import com.project.dto.response.MyPageResponse;
+import com.project.service.MyPageService;
 import com.project.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public class UserController {
 
     private final UserService userService;
+    private final MyPageService myPageService;
 
     @GetMapping("/check")
     public ResponseEntity<ApiResponse<BojCheckResponse>> checkUser(@AuthenticationPrincipal SecurityUserDetails userDetails,
@@ -37,5 +40,17 @@ public class UserController {
                                                       @RequestBody SignUpRequest signUpRequest) {
         userService.signUp(userInfo.getId(), signUpRequest);
         return ResponseEntity.ok(ApiResponse.success("회원가입 성공", null));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(required = false) String date
+    ) {
+        //userDetails.getId()를 통해 현재 로그인한 유저 Pk를 가져와 넘긴다.
+        MyPageResponse response = myPageService.getMyPage(userDetails.getId(), year, month, date);
+        return ResponseEntity.ok(ApiResponse.success("마이페이지 조회 성공", response));
     }
 }

--- a/src/main/java/com/project/dto/response/GrassResponse.java
+++ b/src/main/java/com/project/dto/response/GrassResponse.java
@@ -1,0 +1,7 @@
+package com.project.dto.response;
+
+public record GrassResponse(
+        String date,
+        int solvedCount
+) {
+}

--- a/src/main/java/com/project/dto/response/MyPageDetailResponse.java
+++ b/src/main/java/com/project/dto/response/MyPageDetailResponse.java
@@ -1,0 +1,13 @@
+package com.project.dto.response;
+
+import java.util.List;
+
+public record MyPageDetailResponse(
+        String date,
+        int dailyScore,
+        int dailyRank,
+        int solvedCount,
+        int maxDifficulty,
+        List<ProblemResponse> problems // ProblemResponse 사용
+) {
+}

--- a/src/main/java/com/project/dto/response/MyPageProfileResponse.java
+++ b/src/main/java/com/project/dto/response/MyPageProfileResponse.java
@@ -1,0 +1,9 @@
+package com.project.dto.response;
+
+public record MyPageProfileResponse(
+        String username,
+        String baekjoonId,
+        int tierLevel,
+        Long totalScore
+) {
+}

--- a/src/main/java/com/project/dto/response/MyPageResponse.java
+++ b/src/main/java/com/project/dto/response/MyPageResponse.java
@@ -1,0 +1,11 @@
+package com.project.dto.response;
+
+import java.util.List;
+
+//MyPageResponse.record
+public record MyPageResponse(
+        MyPageProfileResponse profile,
+        List<GrassResponse> grass,
+        MyPageDetailResponse selectedDateDetail
+) {
+}

--- a/src/main/java/com/project/dto/response/ProblemResponse.java
+++ b/src/main/java/com/project/dto/response/ProblemResponse.java
@@ -1,0 +1,8 @@
+package com.project.dto.response;
+
+public record ProblemResponse(
+        String title,
+        int tierLevel,
+        String link
+) {
+}

--- a/src/main/java/com/project/entity/UserProblemRef.java
+++ b/src/main/java/com/project/entity/UserProblemRef.java
@@ -17,11 +17,11 @@ import lombok.NoArgsConstructor;
 public class UserProblemRef {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name ="user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name ="problem_id", nullable = false)
+    @JoinColumn(name = "problem_id", nullable = false)
     private ProblemEntity problem;
 
     public UserProblemRef(UserEntity user, ProblemEntity problem) {

--- a/src/main/java/com/project/entity/UserProblemRef.java
+++ b/src/main/java/com/project/entity/UserProblemRef.java
@@ -1,0 +1,31 @@
+package com.project.entity;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 복합 속성 클래스 (user_id, problem_id)
+ */
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserProblemRef {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name ="user_id", nullable = false)
+    private UserEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name ="problem_id", nullable = false)
+    private ProblemEntity problem;
+
+    public UserProblemRef(UserEntity user, ProblemEntity problem) {
+        this.user = user;
+        this.problem = problem;
+    }
+}

--- a/src/main/java/com/project/entity/UsersProblemEntity.java
+++ b/src/main/java/com/project/entity/UsersProblemEntity.java
@@ -38,7 +38,7 @@ public class UsersProblemEntity {
     private Long usersProblemId;
 
     /**
-     * 복합 속성 (user_id, problem_id)
+     * 복합 속성 (user_id, problem_id) test
      */
     @Embedded
     private UserProblemRef ref;

--- a/src/main/java/com/project/entity/UsersProblemEntity.java
+++ b/src/main/java/com/project/entity/UsersProblemEntity.java
@@ -1,6 +1,13 @@
 package com.project.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/project/entity/UsersProblemEntity.java
+++ b/src/main/java/com/project/entity/UsersProblemEntity.java
@@ -1,22 +1,25 @@
 package com.project.entity;
 
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Column;
-import jakarta.persistence.Table;
-import jakarta.persistence.Entity;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.JoinColumn;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
 import java.time.LocalDateTime;
 
-@Builder
-@Table(name = "users_problem")
+
+
+@Table(
+        name = "users_problem",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_users_problem", columnNames = {"user_id", "problem_id"})
+        }
+)
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UsersProblemEntity {
 
     /**
@@ -27,27 +30,16 @@ public class UsersProblemEntity {
     @Column(name = "users_problem_id")
     private Long usersProblemId;
 
-
     /**
-     * 문제 - FK
+     * 복합 속성 (user_id, problem_id)
      */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "problem_id", nullable = false)
-    private ProblemEntity problem;
-
-
-    /**
-     * 유저 - FK
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private UserEntity user;
+    @Embedded
+    private UserProblemRef ref;
 
 
     /**
      * 문제 풀이 유무 : 초기값 false -> 첫 회원가입 후, 첫 배치때 푼 문제 true 전환
      */
-    @Builder.Default
     @Column(name = "is_solved", nullable = false)
     private boolean isSolved = false;
 
@@ -57,4 +49,12 @@ public class UsersProblemEntity {
      */
     @Column(name = "solved_time")
     private LocalDateTime solvedTime;
+
+
+    @Builder
+    public UsersProblemEntity(UserEntity user, ProblemEntity problem, boolean isSolved, LocalDateTime solvedTime) {
+        this.ref = new UserProblemRef(user, problem);
+        this.isSolved = isSolved;
+        this.solvedTime = solvedTime;
+    }
 }

--- a/src/main/java/com/project/mapper/MyPageMapper.java
+++ b/src/main/java/com/project/mapper/MyPageMapper.java
@@ -15,7 +15,8 @@ import java.util.List;
 public class MyPageMapper {
     public MyPageResponse toResponse(UserEntity user, int totalScore,
             List<GrassResponse> grassList,
-            LocalDate date, int dailyScore, int dailyRank, int solvedCount, int maxDifficulty,
+            LocalDate date,
+            DailyStatistics dailyStats,
             List<ProblemResponse> problemList) {
 
         // 1. 프로필 Record 생성
@@ -29,14 +30,21 @@ public class MyPageMapper {
         // 2. 상세 정보 Record 생성
         MyPageDetailResponse detail = new MyPageDetailResponse(
                 date.toString(),
-                dailyScore,
-                dailyRank,
-                solvedCount,
-                maxDifficulty,
+                dailyStats.dailyScore(),      // Record에서 꺼냄
+                dailyStats.dailyRank(),
+                dailyStats.solvedCount(),
+                dailyStats.maxDifficulty(),
                 problemList
         );
 
         // 3. 최종 Record 조립 후 반환
         return new MyPageResponse(profile, grassList, detail);
+    }
+    public record DailyStatistics(
+            int dailyScore,
+            int dailyRank,
+            int solvedCount,
+            int maxDifficulty
+    ) {
     }
 }

--- a/src/main/java/com/project/mapper/MyPageMapper.java
+++ b/src/main/java/com/project/mapper/MyPageMapper.java
@@ -1,0 +1,42 @@
+package com.project.mapper;
+
+import com.project.dto.response.GrassResponse;
+import com.project.dto.response.MyPageProfileResponse;
+import com.project.dto.response.MyPageResponse;
+import com.project.dto.response.ProblemResponse;
+import com.project.dto.response.MyPageDetailResponse;
+import com.project.entity.UserEntity;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class MyPageMapper {
+    public MyPageResponse toResponse(UserEntity user, int totalScore,
+            List<GrassResponse> grassList,
+            LocalDate date, int dailyScore, int dailyRank, int solvedCount, int maxDifficulty,
+            List<ProblemResponse> problemList) {
+
+        // 1. 프로필 Record 생성
+        MyPageProfileResponse profile = new MyPageProfileResponse(
+                user.getUsername(),
+                user.getBaekjoonId(),
+                user.getBojTier(),
+                (long) totalScore
+        );
+
+        // 2. 상세 정보 Record 생성
+        MyPageDetailResponse detail = new MyPageDetailResponse(
+                date.toString(),
+                dailyScore,
+                dailyRank,
+                solvedCount,
+                maxDifficulty,
+                problemList
+        );
+
+        // 3. 최종 Record 조립 후 반환
+        return new MyPageResponse(profile, grassList, detail);
+    }
+}

--- a/src/main/java/com/project/repository/MyPageRepository.java
+++ b/src/main/java/com/project/repository/MyPageRepository.java
@@ -1,0 +1,72 @@
+package com.project.repository;
+
+import com.project.dto.response.GrassResponse;
+import com.project.dto.response.ProblemResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.project.entity.QProblemEntity.problemEntity;
+import static com.project.entity.QUsersProblemEntity.usersProblemEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class MyPageRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 월간 잔디 데이터 조회
+     */
+    public List<GrassResponse> findGrassList(Long userId, int year, int month) {
+        LocalDateTime startOfMonth = LocalDate.of(year, month, 1).atStartOfDay();
+        LocalDateTime endOfMonth = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1).atTime(23, 59, 59);
+
+        StringExpression dateStr =
+                Expressions.stringTemplate("TO_CHAR({0}, 'YYYY-MM-DD')", usersProblemEntity.solvedTime)
+                        .stringValue();
+
+        return queryFactory
+                .select(Projections.constructor(
+                        GrassResponse.class,
+                        dateStr,
+                        usersProblemEntity.count().intValue()
+                ))
+                .from(usersProblemEntity)
+                .where(
+                        usersProblemEntity.user.userId.eq(userId),
+                        usersProblemEntity.solvedTime.between(startOfMonth, endOfMonth))
+                .groupBy(dateStr)
+                .fetch();
+    }
+
+    /**
+     * 특정 날짜에 푼 문제 상세 목록 조회
+     */
+    public List<ProblemResponse> findSolvedProblemList(Long userId, LocalDate date) {
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(23, 59, 59);
+
+        return queryFactory
+                .select(Projections.constructor(ProblemResponse.class,
+                        problemEntity.problemTitle,
+                        problemEntity.problemLevel,
+                        problemEntity.problemUrl))
+                .from(usersProblemEntity)
+                .join(usersProblemEntity.problem, problemEntity)
+                .where(
+                        usersProblemEntity.user.userId.eq(userId),
+                        usersProblemEntity.isSolved.isTrue(),
+                        usersProblemEntity.solvedTime.between(startOfDay,endOfDay))
+                .orderBy(usersProblemEntity.solvedTime.asc())
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/project/repository/MyPageRepository.java
+++ b/src/main/java/com/project/repository/MyPageRepository.java
@@ -41,7 +41,7 @@ public class MyPageRepository {
                 ))
                 .from(usersProblemEntity)
                 .where(
-                        usersProblemEntity.user.userId.eq(userId),
+                        usersProblemEntity.ref.user.userId.eq(userId),
                         usersProblemEntity.solvedTime.between(startOfMonth, endOfMonth))
                 .groupBy(dateStr)
                 .fetch();
@@ -60,9 +60,9 @@ public class MyPageRepository {
                         problemEntity.problemLevel,
                         problemEntity.problemUrl))
                 .from(usersProblemEntity)
-                .join(usersProblemEntity.problem, problemEntity)
+                .join(usersProblemEntity.ref.problem, problemEntity)
                 .where(
-                        usersProblemEntity.user.userId.eq(userId),
+                        usersProblemEntity.ref.user.userId.eq(userId),
                         usersProblemEntity.isSolved.isTrue(),
                         usersProblemEntity.solvedTime.between(startOfDay, endOfDay))
                 .orderBy(usersProblemEntity.solvedTime.asc())

--- a/src/main/java/com/project/repository/MyPageRepository.java
+++ b/src/main/java/com/project/repository/MyPageRepository.java
@@ -64,7 +64,7 @@ public class MyPageRepository {
                 .where(
                         usersProblemEntity.user.userId.eq(userId),
                         usersProblemEntity.isSolved.isTrue(),
-                        usersProblemEntity.solvedTime.between(startOfDay,endOfDay))
+                        usersProblemEntity.solvedTime.between(startOfDay, endOfDay))
                 .orderBy(usersProblemEntity.solvedTime.asc())
                 .fetch();
     }

--- a/src/main/java/com/project/repository/RankingDayRepository.java
+++ b/src/main/java/com/project/repository/RankingDayRepository.java
@@ -1,0 +1,38 @@
+package com.project.repository;
+
+import com.project.entity.UserEntity;
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RankingDayRepository extends JpaRepository<UserEntity, Long> {
+    /**
+     * 일간 랭킹 계산 (Native Query) 특정 날짜 범위 내에서 각 유저가 획득한 점수(난이도 합)를 계산하고, 내 점수보다 높은 유저의 수를 카운트하여 순위를
+     * 산출합니다.
+     *
+     * @param myScore 내 일간 획득 점수
+     * @param startOfDay 조회 시작 시간 (00:00:00)
+     * @param endOfDay 조회 종료 시간 (23:59:59)
+     * @return 내 등수 (나보다 점수 높은 사람 수 + 1)
+     */
+    @Query(
+            value =
+                    """
+                  SELECT COUNT(*) + 1
+                  FROM (
+                      SELECT up.user_id, SUM(p.problem_level) as total_score
+                      FROM users_problem up
+                      JOIN problem p ON up.problem_id = p.problem_id
+                      WHERE up.solved_time BETWEEN :startOfDay AND :endOfDay
+                      AND up.is_solved = true
+                      GROUP BY up.user_id
+                  ) as daily_stats
+                  WHERE daily_stats.total_score > :myScore
+              """,
+            nativeQuery = true)
+    long calculateDailyRank(
+            @Param("myScore") int myScore,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay);
+}

--- a/src/main/java/com/project/repository/RankingQueryRepository.java
+++ b/src/main/java/com/project/repository/RankingQueryRepository.java
@@ -39,8 +39,8 @@ public class RankingQueryRepository {
                     userEntity.teamName.stringValue()
             ))
             .from(usersProblemEntity)
-            .join(usersProblemEntity.user, userEntity)
-            .join(usersProblemEntity.problem, problemEntity)
+            .join(usersProblemEntity.ref.user, userEntity)
+            .join(usersProblemEntity.ref.problem, problemEntity)
             .where(
                     usersProblemEntity.solvedTime.goe(start),
                     usersProblemEntity.solvedTime.lt(endExclusive),

--- a/src/main/java/com/project/repository/UsersProblemRepository.java
+++ b/src/main/java/com/project/repository/UsersProblemRepository.java
@@ -11,17 +11,18 @@ import java.util.List;
 public interface UsersProblemRepository extends JpaRepository<UsersProblemEntity, Long> {
     @Query("""
         SELECT new com.project.dto.DailyRankRawData(
-            u.user.userId,
-            u.user.username,
+            usr.userId,
+            usr.username,
             COUNT(u),
             SUM(p.problemLevel)
         )
         FROM UsersProblemEntity u
-        JOIN u.problem p
+         JOIN u.ref.user usr
+         JOIN u.ref.problem p
         WHERE u.isSolved = true
           AND u.solvedTime BETWEEN :start AND :end
-        GROUP BY u.user.userId, u.user.username
-        ORDER BY SUM(p.problemLevel) DESC, u.user.username ASC
+        GROUP BY usr.userId, usr.username
+        ORDER BY SUM(p.problemLevel) DESC, usr.username ASC
     """)
     List<DailyRankRawData> findDailyRank(LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/project/service/MyPageService.java
+++ b/src/main/java/com/project/service/MyPageService.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service

--- a/src/main/java/com/project/service/MyPageService.java
+++ b/src/main/java/com/project/service/MyPageService.java
@@ -1,0 +1,102 @@
+package com.project.service;
+
+import com.project.common.exception.BusinessException;
+import com.project.common.exception.ErrorCode;
+import com.project.dto.response.GrassResponse;
+import com.project.dto.response.MyPageResponse;
+import com.project.dto.response.ProblemResponse;
+import com.project.entity.UserEntity;
+import com.project.mapper.MyPageMapper;
+import com.project.repository.MyPageRepository;
+import com.project.repository.RankingDayRepository;
+import com.project.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final MyPageRepository myPageRepository;
+    private final RankingDayRepository rankingDayRepository;
+    private final MyPageMapper myPageMapper; // Mapper 주입
+
+    public MyPageResponse getMyPage(Long userId, int year, int month, String dateStr) {
+
+        // 1. 데이터 조회 및 계산
+        // 1. 유저 조회
+        UserEntity user = userRepository.findById(userId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. 기준 날짜 설정 & 유효성 검증
+        LocalDate targetDate = determineTargetDate(year, month, dateStr);
+
+        // 3. 잔디: 월간 데이터 조회
+        List<GrassResponse> grassList = myPageRepository.findGrassList(userId, year, month);
+
+        // 4. 상세: 일간 문제 목록 조회 (푼 시간 정렬)
+        List<ProblemResponse> problemList =
+                myPageRepository.findSolvedProblemList(userId, targetDate);
+
+        // 5. 통계 계산
+        int solvedCount = problemList.size();
+
+        int dailyScore =
+                problemList.stream().mapToInt(ProblemResponse::tierLevel).sum();
+        int maxDifficulty =
+                problemList.stream().mapToInt(ProblemResponse::tierLevel).max().orElse(0);
+
+        // 6. 상세: 일간 랭킹 계산 (Native Query)
+        int dailyRank = 0;
+        if (solvedCount > 0) {
+            LocalDateTime startOfDay = targetDate.atStartOfDay();
+            LocalDateTime nextDayStart = targetDate.plusDays(1).atStartOfDay();
+
+            long rankResult = rankingDayRepository.calculateDailyRank(
+                    dailyScore,
+                    startOfDay,
+                    nextDayStart
+            );
+            dailyRank = Math.toIntExact(rankResult);
+        }
+
+        // 7. 전체 랭킹 및 점수
+        int totalSolvedCount = user.getTotalSolvedCount() != null ? user.getTotalSolvedCount() : 0;
+
+        return myPageMapper.toResponse(
+                user,
+                totalSolvedCount,
+                grassList,
+                targetDate,
+                dailyScore,
+                (int) dailyRank,
+                solvedCount,
+                maxDifficulty,
+                problemList
+        );
+
+
+    }
+    private LocalDate determineTargetDate(int year, int month, String dateStr) {
+        try {
+            if (dateStr != null && !dateStr.isBlank()) {
+                return LocalDate.parse(dateStr);
+            }
+            LocalDate today = LocalDate.now();
+            if (year == today.getYear() && month == today.getMonthValue()) {
+                return today;
+            }
+            return LocalDate.of(year, month, 1);
+        } catch (DateTimeException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "날짜 형식이 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/test/java/com/project/config/TestContainerConfig.java
+++ b/src/test/java/com/project/config/TestContainerConfig.java
@@ -3,9 +3,11 @@ package com.project.config;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 @TestConfiguration
+@EnableJpaAuditing
 public class TestContainerConfig {
 
     @Bean

--- a/src/test/java/com/project/config/TestQueryDslConfig.java
+++ b/src/test/java/com/project/config/TestQueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.project.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/project/controller/UserControllerTest.java
+++ b/src/test/java/com/project/controller/UserControllerTest.java
@@ -7,10 +7,16 @@ import com.project.common.security.jwt.refresh.RefreshTokenProvider;
 import com.project.common.util.BojUtil;
 import com.project.common.util.SlackUtil;
 import com.project.dto.request.SignUpRequest;
+import com.project.dto.response.GrassResponse;
+import com.project.dto.response.MyPageDetailResponse;
+import com.project.dto.response.MyPageResponse;
+import com.project.dto.response.ProblemResponse;
+import com.project.dto.response.MyPageProfileResponse;
 import com.project.entity.EurekaTeamName;
 import com.project.entity.UserEntity;
 import com.project.repository.RefreshTokenRepository;
 import com.project.repository.UserRepository;
+import com.project.service.MyPageService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,10 +32,15 @@ import org.springframework.test.context.jdbc.SqlGroup;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -54,6 +65,8 @@ class UserControllerTest {
     RefreshTokenRepository refreshTokenRepository;
     @MockitoBean
     BojUtil bojUtil;
+    @MockitoBean
+    MyPageService myPageService;
     @Autowired
     MockMvc mockMvc;
     @Autowired
@@ -117,5 +130,52 @@ class UserControllerTest {
         assertThat(updatedUser.getUsername()).isEqualTo("이규동");
         assertThat(updatedUser.getTeamName()).isEqualTo(EurekaTeamName.BACKEND_FACE);
         assertThat(updatedUser.getBojTier()).isEqualTo(14);
+    }
+    @Test
+    @DisplayName("마이페이지 조회 성공 테스트")
+    void getMyPage() throws Exception {
+        // Given
+        int year = 2025;
+        int month = 12;
+        String dateStr = "2025-12-05";
+        Long userId = 1L;
+
+        // 1. Mock 데이터 생성 (Record 생성자 순서 및 타입 주의)
+        MyPageProfileResponse profileMock = new MyPageProfileResponse("이규동", "dlrbehd120", 14,   // tierLevel (bojTier 아님)
+                100L  // totalScore
+        );
+
+        // GrassResponse (로그상 키값: date, solvedCount)
+        List<GrassResponse> grassMock = List.of(new GrassResponse("2025-12-05", 2));
+
+        // MyPageDetailResponse (로그상 키값: date, dailyScore, dailyRank, solvedCount, maxDifficulty, problems)
+        MyPageDetailResponse detailMock = new MyPageDetailResponse(dateStr, 15, // dailyScore
+                1,  // dailyRank
+                2,  // solvedCount
+                10, // maxDifficulty
+                List.of(new ProblemResponse("A+B", 1, "url")));
+
+        // MyPageResponse 조립
+        MyPageResponse mockResponse = new MyPageResponse(profileMock, grassMock, detailMock);
+
+        // Service Mocking
+        // (파라미터 매칭을 위해 any() 사용하거나 정확한 값 입력)
+        when(myPageService.getMyPage(any(), anyInt(), anyInt(), any())).thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/user/me").param("year", String.valueOf(year)).param("month", String.valueOf(month)).param("date", dateStr)).andExpect(status().isOk()).andDo(print()) // 성공 시 로그 출력
+
+                // 1. 공통 응답 확인
+                .andExpect(jsonPath("$.message").value("마이페이지 조회 성공"))
+
+                // 2. Profile 검증 (Record 필드명: tierLevel)
+                .andExpect(jsonPath("$.data.profile.username").value("이규동")).andExpect(jsonPath("$.data.profile.baekjoonId").value("dlrbehd120")).andExpect(jsonPath("$.data.profile.tierLevel").value(14))
+
+                // 3. Grass 검증 (로그상 키값: solvedCount)
+                .andExpect(jsonPath("$.data.grass[0].date").value("2025-12-05")).andExpect(jsonPath("$.data.grass[0].solvedCount").value(2)) // count -> solvedCount 수정
+
+                // 4. Detail 검증 (★중요: detail -> selectedDateDetail)
+                // Record 내부 변수명이 selectedDateDetail이라서 JSON 키도 그렇게 나옵니다.
+                .andExpect(jsonPath("$.data.selectedDateDetail.date").value("2025-12-05")).andExpect(jsonPath("$.data.selectedDateDetail.dailyScore").value(15)).andExpect(jsonPath("$.data.selectedDateDetail.solvedCount").value(2));
     }
 }

--- a/src/test/java/com/project/mapper/MyPageMapperTest.java
+++ b/src/test/java/com/project/mapper/MyPageMapperTest.java
@@ -1,0 +1,89 @@
+package com.project.mapper;
+
+import com.project.dto.response.GrassResponse;
+import com.project.dto.response.MyPageResponse;
+import com.project.dto.response.ProblemResponse;
+import com.project.entity.UserEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class MyPageMapperTest {
+    private final MyPageMapper myPageMapper = new MyPageMapper();
+
+    @Test
+    @DisplayName("UserEntity와 통계 데이터를 받아 MyPageResponse로 정확히 반환")
+    void toResponse_Success() {
+        // given
+        String username = "테스트유저";
+        String baekjoonId = "boj_user";
+        int bojTier = 15;
+        UserEntity user = UserEntity.builder()
+                .username(username)
+                .baekjoonId(baekjoonId)
+                .bojTier(bojTier)
+                .build();
+
+        // 2. 통계 데이터 준비
+        int totalScore = 5000;
+        LocalDate date = LocalDate.of(2025, 12, 15);
+
+        MyPageMapper.DailyStatistics dailyStats = new MyPageMapper.DailyStatistics(
+                100, // dailyScore
+                1,   // dailyRank
+                3,   // solvedCount
+                15   // maxDifficulty
+        );
+
+        // 3. 리스트 데이터 준비
+        List<GrassResponse> grassList = List.of(
+                new GrassResponse("2025-12-14", 5),
+                new GrassResponse("2025-12-15", 3)
+        );
+
+        List<ProblemResponse> problemList = List.of(
+                new ProblemResponse("문제1", 5, "url1"),
+                new ProblemResponse("문제2", 10, "url2")
+        );
+
+        // when
+        MyPageResponse response = myPageMapper.toResponse(
+                user,
+                totalScore,
+                grassList,
+                date,
+                dailyStats,
+                problemList
+        );
+
+        // then
+        assertThat(response).isNotNull();
+
+        // 프로필
+        assertThat(response.profile().username()).isEqualTo(username);
+        assertThat(response.profile().baekjoonId()).isEqualTo(baekjoonId);
+        assertThat(response.profile().tierLevel()).isEqualTo(bojTier); // DTO 필드명 확인 (tierLevel)
+        assertThat(response.profile().totalScore()).isEqualTo(totalScore);
+
+        // 2. 상세 정보 검증 (Detail)
+        assertThat(response.selectedDateDetail().date()).isEqualTo(date.toString());
+        assertThat(response.selectedDateDetail().dailyScore()).isEqualTo(dailyStats.dailyScore());
+        assertThat(response.selectedDateDetail().dailyRank()).isEqualTo(dailyStats.dailyRank());
+        assertThat(response.selectedDateDetail().solvedCount()).isEqualTo(dailyStats.solvedCount());
+        assertThat(response.selectedDateDetail().maxDifficulty()).isEqualTo(dailyStats.maxDifficulty());
+
+        // 문제 목록 검증
+        assertThat(response.selectedDateDetail().problems()).hasSize(2);
+        assertThat(response.selectedDateDetail().problems().get(0).title()).isEqualTo("문제1");
+
+        // 3. 잔디 검증
+        assertThat(response.grass()).hasSize(2);
+        assertThat(response.grass().get(0).date()).isEqualTo("2025-12-14");
+    }
+
+}

--- a/src/test/java/com/project/mapper/MyPageMapperTest.java
+++ b/src/test/java/com/project/mapper/MyPageMapperTest.java
@@ -4,6 +4,7 @@ import com.project.dto.response.GrassResponse;
 import com.project.dto.response.MyPageResponse;
 import com.project.dto.response.ProblemResponse;
 import com.project.entity.UserEntity;
+import com.project.mapper.MyPageMapper.DailyStatistics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,78 +13,73 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 class MyPageMapperTest {
+
     private final MyPageMapper myPageMapper = new MyPageMapper();
 
     @Test
-    @DisplayName("UserEntity와 통계 데이터를 받아 MyPageResponse로 정확히 반환")
+    @DisplayName("UserEntity와 통계 데이터를 받아 MyPageResponse로 정확히 변환해야 한다.")
     void toResponse_Success() {
         // given
-        String username = "테스트유저";
-        String baekjoonId = "boj_user";
-        int bojTier = 15;
-        UserEntity user = UserEntity.builder()
-                .username(username)
-                .baekjoonId(baekjoonId)
-                .bojTier(bojTier)
-                .build();
-
-        // 2. 통계 데이터 준비
-        int totalScore = 5000;
+        UserEntity user = createUser();
+        DailyStatistics dailyStats = createDailyStats();
+        List<GrassResponse> grassList = createGrassList();
+        List<ProblemResponse> problemList = createProblemList();
         LocalDate date = LocalDate.of(2025, 12, 15);
-
-        MyPageMapper.DailyStatistics dailyStats = new MyPageMapper.DailyStatistics(
-                100, // dailyScore
-                1,   // dailyRank
-                3,   // solvedCount
-                15   // maxDifficulty
-        );
-
-        // 3. 리스트 데이터 준비
-        List<GrassResponse> grassList = List.of(
-                new GrassResponse("2025-12-14", 5),
-                new GrassResponse("2025-12-15", 3)
-        );
-
-        List<ProblemResponse> problemList = List.of(
-                new ProblemResponse("문제1", 5, "url1"),
-                new ProblemResponse("문제2", 10, "url2")
-        );
+        int totalScore = 5000;
 
         // when
         MyPageResponse response = myPageMapper.toResponse(
-                user,
-                totalScore,
-                grassList,
-                date,
-                dailyStats,
-                problemList
+                user, totalScore, grassList, date, dailyStats, problemList
         );
 
         // then
         assertThat(response).isNotNull();
 
-        // 프로필
-        assertThat(response.profile().username()).isEqualTo(username);
-        assertThat(response.profile().baekjoonId()).isEqualTo(baekjoonId);
-        assertThat(response.profile().tierLevel()).isEqualTo(bojTier); // DTO 필드명 확인 (tierLevel)
-        assertThat(response.profile().totalScore()).isEqualTo(totalScore);
+        // 1. 프로필 검증
+        assertThat(response.profile().username()).isEqualTo("테스트유저");
+        assertThat(response.profile().baekjoonId()).isEqualTo("boj_user");
+        assertThat(response.profile().tierLevel()).isEqualTo(15);
+        assertThat(response.profile().totalScore()).isEqualTo(5000);
 
-        // 2. 상세 정보 검증 (Detail)
+        // 2. 상세 정보 검증
         assertThat(response.selectedDateDetail().date()).isEqualTo(date.toString());
-        assertThat(response.selectedDateDetail().dailyScore()).isEqualTo(dailyStats.dailyScore());
-        assertThat(response.selectedDateDetail().dailyRank()).isEqualTo(dailyStats.dailyRank());
-        assertThat(response.selectedDateDetail().solvedCount()).isEqualTo(dailyStats.solvedCount());
-        assertThat(response.selectedDateDetail().maxDifficulty()).isEqualTo(dailyStats.maxDifficulty());
+        assertThat(response.selectedDateDetail().dailyScore()).isEqualTo(100);
+        assertThat(response.selectedDateDetail().dailyRank()).isEqualTo(1);
+        assertThat(response.selectedDateDetail().solvedCount()).isEqualTo(3);
+        assertThat(response.selectedDateDetail().maxDifficulty()).isEqualTo(15);
 
-        // 문제 목록 검증
+        // 3. 문제 및 잔디 목록 검증
         assertThat(response.selectedDateDetail().problems()).hasSize(2);
         assertThat(response.selectedDateDetail().problems().get(0).title()).isEqualTo("문제1");
-
-        // 3. 잔디 검증
         assertThat(response.grass()).hasSize(2);
-        assertThat(response.grass().get(0).date()).isEqualTo("2025-12-14");
     }
 
+    // --- Helper Methods to Reduce Method Length ---
+
+    private UserEntity createUser() {
+        return UserEntity.builder()
+                .username("테스트유저")
+                .baekjoonId("boj_user")
+                .bojTier(15)
+                .build();
+    }
+
+    private DailyStatistics createDailyStats() {
+        return new DailyStatistics(100, 1, 3, 15);
+    }
+
+    private List<GrassResponse> createGrassList() {
+        return List.of(
+                new GrassResponse("2025-12-14", 5),
+                new GrassResponse("2025-12-15", 3)
+        );
+    }
+
+    private List<ProblemResponse> createProblemList() {
+        return List.of(
+                new ProblemResponse("문제1", 5, "url1"),
+                new ProblemResponse("문제2", 10, "url2")
+        );
+    }
 }

--- a/src/test/java/com/project/repository/MyPageRepositoryTest.java
+++ b/src/test/java/com/project/repository/MyPageRepositoryTest.java
@@ -4,7 +4,11 @@ import com.project.config.TestContainerConfig;
 import com.project.config.TestQueryDslConfig;
 import com.project.dto.response.GrassResponse;
 import com.project.dto.response.ProblemResponse;
-import com.project.entity.*;
+import com.project.entity.EurekaTeamName;
+import com.project.entity.ProblemEntity;
+import com.project.entity.UserEntity;
+import com.project.entity.UsersProblemEntity;
+import com.project.entity.UserRole;
 import jakarta.persistence.EntityManager;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/project/repository/MyPageRepositoryTest.java
+++ b/src/test/java/com/project/repository/MyPageRepositoryTest.java
@@ -1,0 +1,128 @@
+package com.project.repository;
+
+import com.project.config.TestContainerConfig;
+import com.project.config.TestQueryDslConfig;
+import com.project.dto.response.GrassResponse;
+import com.project.dto.response.ProblemResponse;
+import com.project.entity.*;
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DataJpaTest
+@Import({TestContainerConfig.class, TestQueryDslConfig.class, MyPageRepository.class})
+class MyPageRepositoryTest {
+
+    @Autowired
+    private MyPageRepository myPageRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        // 1. 테스트용 메인 유저 생성
+        user = UserEntity.builder()
+                .slackId("123")
+                .baekjoonId("gkdud0909")
+                .username("최하영")
+                .totalSolvedCount(10)
+                .bojTier(14)
+                .isAlertAgreed(true)
+                .isDeleted(false)
+                .userRole(UserRole.USER)
+                .teamName(EurekaTeamName.BACKEND_FACE)
+                // [핵심] 빌더 사용 시 테스트 환경에서는 날짜가 자동 주입 안 될 수 있으므로 명시
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+        em.persist(user);
+
+        // 2. 문제 더미 데이터 생성
+        ProblemEntity p1 = createProblem(1001, "별찍기", 5);
+        ProblemEntity p2 = createProblem(1002, "A+B", 10);
+
+        // 3. 풀이 기록 생성 (시나리오: 12월 5일에 2문제 해결)
+        // p2(A+B)는 오전 10시, p1(별찍기)는 오후 2시 -> 오름차순 정렬 시 p2가 먼저 나와야 함
+        createSolvedHistory(user, p1, LocalDate.of(2025, 12, 5).atTime(14, 0));
+        createSolvedHistory(user, p2, LocalDate.of(2025, 12, 5).atTime(10, 0));
+
+        // 4. 영속성 컨텍스트 초기화 (쿼리가 실제로 DB로 날아가도록)
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("월간 잔디 조회: 날짜별로 그룹핑되어 풀이 수가 정확히 나와야한다.")
+    void findGrassListTest() {
+        // given
+        int year = 2025;
+        int month = 12;
+
+        // when
+        List<GrassResponse> result =
+                myPageRepository.findGrassList(user.getUserId(), year, month);
+
+        // then
+        assertThat(result).hasSize(1); // 5일 하루 -> 1개 데이터
+
+        GrassResponse dayData = result.get(0);
+        assertThat(dayData.date()).isEqualTo("2025-12-05");
+        assertThat(dayData.solvedCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("일간 문제 상세 조회: 해당 날짜의 solved=true만 오름차순으로 조회되어야 한다.")
+    void findSolvedProblemListTest() {
+        // given
+        LocalDate date = LocalDate.of(2025, 12, 5);
+
+        // when
+        List<ProblemResponse> result =
+                myPageRepository.findSolvedProblemList(user.getUserId(), date);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).title()).isEqualTo("A+B");   // 10:00
+        assertThat(result.get(1).title()).isEqualTo("별찍기"); // 14:00
+    }
+
+
+
+    private ProblemEntity createProblem(int id, String title, int level) {
+        ProblemEntity p = ProblemEntity.builder()
+                .problemId(id)
+                .problemTitle(title)
+                .problemLevel(level)
+                .problemUrl("url")
+                .build();
+        em.persist(p);
+        return p;
+    }
+
+    private void createSolvedHistory(UserEntity u, ProblemEntity p, LocalDateTime time) {
+        em.persist(
+                UsersProblemEntity.builder()
+                        .user(u)
+                        .problem(p)
+                        .isSolved(true)
+                        .solvedTime(time)
+                        .build()
+        );
+    }
+}
+

--- a/src/test/java/com/project/repository/RankingDayRepositoryTest.java
+++ b/src/test/java/com/project/repository/RankingDayRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.project.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.project.config.TestContainerConfig;
+import com.project.entity.ProblemEntity;
+import com.project.entity.UserEntity;
+import com.project.entity.
+        UsersProblemEntity;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestContainerConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class RankingDayRepositoryTest {
+
+    @Autowired RankingDayRepository rankingDayRepository;
+    @Autowired EntityManager em;
+
+    @Test
+    @DisplayName("일간 랭킹: 나보다 점수 높은 사람이 1명이면 내 등수는 2등이어야 한다.")
+    void calculateDailyRankTest() {
+        // given
+        UserEntity me = createUser("최하영");
+        UserEntity otherHigh = createUser("고수야");
+        UserEntity otherLow = createUser("하수야");
+        // 문제 생성
+        ProblemEntity p10 = createProblem(10);
+        ProblemEntity p20 = createProblem(20);
+        ProblemEntity p5 = createProblem(5);
+
+        // 문제 풀이 ( 오늘 날짜)
+        LocalDateTime today = LocalDate.now().atTime(12, 0);
+
+        // 나 - 레벨 10
+        solve(me, p10, today);
+        // 고수 - 20
+        solve(otherHigh, p20, today);
+        // 하수 - 5
+        solve(otherLow, p5, today);
+
+        // db 반영
+        em.flush();
+        em.clear();
+
+        // when
+        // 나의 점수는 10점이라고 가정하고 랭킹 조회
+        int myScore = 10;
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
+
+        long rank = rankingDayRepository.calculateDailyRank(myScore, startOfDay, endOfDay);
+
+        // then
+        assertThat(rank).isEqualTo(2);
+    }
+
+    private UserEntity createUser(String name) {
+        UserEntity u =
+                UserEntity.builder()
+                        .slackId(name)
+                        .baekjoonId(name)
+                        .username(name)
+                        .totalSolvedCount(0)
+                        .build();
+        em.persist(u);
+        return u;
+    }
+
+    private ProblemEntity createProblem(int level) {
+        ProblemEntity p =
+                ProblemEntity.builder()
+                        .problemId(1000 + level)
+                        .problemTitle("Level " + level)
+                        .problemLevel(level)
+                        .problemUrl("url")
+                        .build();
+        em.persist(p);
+        return p;
+    }
+
+    private void solve(UserEntity u, ProblemEntity p, LocalDateTime time) {
+        em.persist(
+                UsersProblemEntity.builder().user(u).problem(p).isSolved(true).solvedTime(time).build());
+    }
+}

--- a/src/test/java/com/project/service/MyPageServiceTest.java
+++ b/src/test/java/com/project/service/MyPageServiceTest.java
@@ -1,0 +1,185 @@
+package com.project.service;
+
+import com.project.common.exception.BusinessException;
+import com.project.common.exception.ErrorCode;
+import com.project.dto.response.GrassResponse;
+import com.project.dto.response.MyPageResponse;
+import com.project.dto.response.ProblemResponse;
+import com.project.entity.UserEntity;
+import com.project.mapper.MyPageMapper;
+import com.project.repository.MyPageRepository;
+import com.project.repository.RankingDayRepository;
+import com.project.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MyPageServiceTest {
+
+    @InjectMocks
+    private MyPageService myPageService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MyPageRepository myPageRepository;
+
+    @Mock
+    private RankingDayRepository rankingDayRepository;
+
+    @Mock
+    private MyPageMapper myPageMapper;
+
+    @Test
+    @DisplayName("성공: 유저가 존재하고 문제를 풀었을 때, 통계(합계, 최대값)와 랭킹이 정상 계산되어야 한다.")
+    void getMyPage_Success() {
+        // given
+        Long userId = 1L;
+        int year = 2025;
+        int month = 12;
+        String dateStr = "2025-12-05";
+        LocalDate targetDate = LocalDate.parse(dateStr);
+
+        // 1. Mock User
+        UserEntity mockUser = UserEntity.builder()
+                .userId(userId)
+                .username("testUser")
+                .totalSolvedCount(100)
+                .build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
+        // 2. Mock Grass List (빈 리스트여도 상관없음)
+        given(myPageRepository.findGrassList(userId, year, month)).willReturn(Collections.emptyList());
+
+        // 3. Mock Problem List (통계 계산 검증용 핵심 데이터)
+        // 난이도 5, 난이도 10인 문제 2개를 풀었다고 가정
+        List<ProblemResponse> mockProblems = List.of(
+                new ProblemResponse("A", 5, "url1"),  // tierLevel: 5
+                new ProblemResponse("B", 10, "url2")  // tierLevel: 10
+        );
+        given(myPageRepository.findSolvedProblemList(userId, targetDate)).willReturn(mockProblems);
+
+        // 4. Mock Ranking (문제를 풀었으므로 랭킹 조회 호출됨)
+        given(rankingDayRepository.calculateDailyRank(anyInt(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(1L); // 1등이라고 가정
+
+        // 5. Mock Mapper (결과 반환용)
+        MyPageResponse mockResponse = mock(MyPageResponse.class);
+        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), anyInt(), anyInt(), anyInt(), anyInt(), anyList()))
+                .willReturn(mockResponse);
+
+        // when
+        MyPageResponse result = myPageService.getMyPage(userId, year, month, dateStr);
+
+        // then
+        assertThat(result).isNotNull();
+
+        // [핵심 검증] Mapper에게 전달된 파라미터가 비즈니스 로직대로 계산되었는지 확인
+        verify(myPageMapper).toResponse(
+                eq(mockUser),
+                eq(100),                // totalSolvedCount
+                anyList(),              // grassList
+                eq(targetDate),         // date
+                eq(15),                 // dailyScore (5 + 10 = 15) -> 계산 로직 검증
+                eq(1),                  // dailyRank (Mock 반환값)
+                eq(2),                  // solvedCount (List size)
+                eq(10),                 // maxDifficulty (Max 10) -> 계산 로직 검증
+                eq(mockProblems)        // problemList
+        );
+
+        // 랭킹 리포지토리가 호출되었는지 확인
+        verify(rankingDayRepository, times(1))
+                .calculateDailyRank(eq(15), any(LocalDateTime.class), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("성공: 해당 날짜에 푼 문제가 없을 경우, 점수와 랭킹은 0이어야 하며 랭킹 DB 조회는 건너뛰어야 한다.")
+    void getMyPage_NoSolvedProblems() {
+        // given
+        Long userId = 1L;
+        String dateStr = "2025-12-05";
+        LocalDate targetDate = LocalDate.parse(dateStr);
+
+        UserEntity mockUser = UserEntity.builder().userId(userId).totalSolvedCount(0).build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(myPageRepository.findSolvedProblemList(userId, targetDate)).willReturn(Collections.emptyList()); // 빈 리스트
+
+        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), anyInt(), anyInt(), anyInt(), anyInt(), anyList()))
+                .willReturn(mock(MyPageResponse.class));
+
+        // when
+        myPageService.getMyPage(userId, 2025, 12, dateStr);
+
+        // then
+        // [핵심 검증] 0으로 계산되어 Mapper에 전달되었는지 확인
+        verify(myPageMapper).toResponse(
+                eq(mockUser),
+                eq(0),
+                anyList(),
+                eq(targetDate),
+                eq(0),  // dailyScore
+                eq(0),  // dailyRank
+                eq(0),  // solvedCount
+                eq(0),  // maxDifficulty
+                eq(Collections.emptyList())
+        );
+
+        // [중요] 문제가 없으면 랭킹 조회 쿼리가 실행되지 않아야 함 (성능 최적화 확인)
+        verify(rankingDayRepository, never()).calculateDailyRank(anyInt(), any(), any());
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 유저 ID 요청 시 예외가 발생해야 한다.")
+    void getMyPage_UserNotFound() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> myPageService.getMyPage(userId, 2025, 12, "2025-12-05"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("날짜 로직 검증: dateStr이 null이면 year/month의 1일이나 오늘 날짜가 설정되어야 한다.")
+    void getMyPage_DateLogic() {
+        // given
+        Long userId = 1L;
+        int pastYear = 2020; // 과거
+        int pastMonth = 1;
+
+        UserEntity mockUser = UserEntity.builder().userId(userId).build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(myPageRepository.findSolvedProblemList(any(), any())).willReturn(Collections.emptyList());
+        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), anyInt(), anyInt(), anyInt(), anyInt(), anyList()))
+                .willReturn(mock(MyPageResponse.class));
+
+        // when: 날짜 문자열 없이(null) 호출
+        myPageService.getMyPage(userId, pastYear, pastMonth, null);
+
+        // then: Mapper에 넘어간 날짜가 "2020-01-01"인지 확인
+        verify(myPageMapper).toResponse(
+                any(), anyInt(), anyList(),
+                eq(LocalDate.of(2020, 1, 1)), // 기대값
+                anyInt(), anyInt(), anyInt(), anyInt(), anyList()
+        );
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- #이슈번호
#30
---

## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
가독성과 불변성을 위해 Java Record를 활용하여 DTO를 분리하고, 조립을 담당하는 Mapper를 별도로 구현했습니다.

### 1. Response DTO 구조화 (Java Record 적용)

기존의 일반 Class 형태의 DTO 대신, 데이터 전달 목적에 충실한 record 타입을 적용했습니다.

응답 데이터의 계층 구조를 명확히 하기 위해 내부 레코드를 분리했습니다.

MyPageProfileResponse (프로필 정보)

GrassResponse (잔디 데이터)

MyPageDetailResponse (상세 통계 및 문제 목록)

MyPageResponse (위 3가지를 포함하는 최종 응답)

### 2. Mapper 컴포넌트 구현 (MyPageMapper)

Service 계층의 역할 축소: Service는 비즈니스 로직(데이터 조회 및 계산)에만 집중하도록 변경했습니다.

책임 분리: 조회된 데이터를 최종 응답 객체로 조립(Assembly)하는 역할은 MyPageMapper에게 위임했습니다.
---

## ⌨ 기타
