### PR TITLE
fix: 마이페이지 잔디 조회시 회원가입 직후 초기 배치 데이터 집계 제외 로직 구현 

### DIFF
--- a/src/main/java/com/project/repository/MyPageRepository.java
+++ b/src/main/java/com/project/repository/MyPageRepository.java
@@ -3,7 +3,6 @@ package com.project.repository;
 import com.project.dto.response.GrassResponse;
 import com.project.dto.response.ProblemResponse;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -25,10 +24,8 @@ public class MyPageRepository {
 
     /**
      * 월간 잔디 데이터 조회
-     * @param ignoreStart 제외할 시간 범위 시작 (가입 직후 배치 시작 시간)
-     * @param ignoreEnd 제외할 시간 범위 끝 (가입 직후 배치 종료 시간)
      */
-    public List<GrassResponse> findGrassList(Long userId, int year, int month, LocalDateTime ignoreStart, LocalDateTime ignoreEnd) {
+    public List<GrassResponse> findGrassList(Long userId, int year, int month, LocalDateTime validAfter) {
         LocalDateTime startOfMonth = LocalDate.of(year, month, 1).atStartOfDay();
         LocalDateTime endOfMonth = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1).atTime(23, 59, 59);
 
@@ -46,7 +43,7 @@ public class MyPageRepository {
                 .where(
                         usersProblemEntity.ref.user.userId.eq(userId),
                         usersProblemEntity.solvedTime.between(startOfMonth, endOfMonth),
-                        ignoreBatchTime(ignoreStart, ignoreEnd)
+                        usersProblemEntity.solvedTime.goe(validAfter)
                 )
                 .groupBy(dateStr)
                 .orderBy(dateStr.asc())
@@ -56,7 +53,7 @@ public class MyPageRepository {
     /**
      * 특정 날짜에 푼 문제 상세 목록 조회
      */
-    public List<ProblemResponse> findSolvedProblemList(Long userId, LocalDate date, LocalDateTime ignoreStart, LocalDateTime ignoreEnd) {
+    public List<ProblemResponse> findSolvedProblemList(Long userId, LocalDate date, LocalDateTime validAfter) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(23, 59, 59, 999_999_999);
 
@@ -71,16 +68,9 @@ public class MyPageRepository {
                         usersProblemEntity.ref.user.userId.eq(userId),
                         usersProblemEntity.isSolved.isTrue(),
                         usersProblemEntity.solvedTime.between(startOfDay, endOfDay),
-                        ignoreBatchTime(ignoreStart, ignoreEnd)
+                        usersProblemEntity.solvedTime.goe(validAfter)
                 )
                 .orderBy(usersProblemEntity.solvedTime.asc())
                 .fetch();
     }
-    private BooleanExpression ignoreBatchTime(LocalDateTime start, LocalDateTime end) {
-        if (start == null || end == null) {
-            return null; // QueryDSL에서 null을 반환하면 Where 절에서 자동으로 제거됨
-        }
-        return usersProblemEntity.solvedTime.notBetween(start, end);
-    }
-
 }

--- a/src/main/java/com/project/repository/MyPageRepository.java
+++ b/src/main/java/com/project/repository/MyPageRepository.java
@@ -55,9 +55,9 @@ public class MyPageRepository {
     /**
      * 특정 날짜에 푼 문제 상세 목록 조회
      */
-    public List<ProblemResponse> findSolvedProblemList(Long userId, LocalDate date) {
+    public List<ProblemResponse> findSolvedProblemList(Long userId, LocalDate date, LocalDateTime ignoreStart, LocalDateTime ignoreEnd) {
         LocalDateTime startOfDay = date.atStartOfDay();
-        LocalDateTime endOfDay = date.atTime(23, 59, 59);
+        LocalDateTime endOfDay = date.atTime(23, 59, 59, 999_999_999);
 
         return queryFactory
                 .select(Projections.constructor(ProblemResponse.class,
@@ -69,7 +69,9 @@ public class MyPageRepository {
                 .where(
                         usersProblemEntity.ref.user.userId.eq(userId),
                         usersProblemEntity.isSolved.isTrue(),
-                        usersProblemEntity.solvedTime.between(startOfDay, endOfDay))
+                        usersProblemEntity.solvedTime.between(startOfDay, endOfDay),
+                        usersProblemEntity.solvedTime.notBetween(ignoreStart, ignoreEnd)
+                )
                 .orderBy(usersProblemEntity.solvedTime.asc())
                 .fetch();
     }

--- a/src/main/java/com/project/repository/MyPageRepository.java
+++ b/src/main/java/com/project/repository/MyPageRepository.java
@@ -24,8 +24,10 @@ public class MyPageRepository {
 
     /**
      * 월간 잔디 데이터 조회
+     * @param ignoreStart 제외할 시간 범위 시작 (가입 직후 배치 시작 시간)
+     * @param ignoreEnd 제외할 시간 범위 끝 (가입 직후 배치 종료 시간)
      */
-    public List<GrassResponse> findGrassList(Long userId, int year, int month) {
+    public List<GrassResponse> findGrassList(Long userId, int year, int month, LocalDateTime ignoreStart, LocalDateTime ignoreEnd) {
         LocalDateTime startOfMonth = LocalDate.of(year, month, 1).atStartOfDay();
         LocalDateTime endOfMonth = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1).atTime(23, 59, 59);
 
@@ -42,8 +44,11 @@ public class MyPageRepository {
                 .from(usersProblemEntity)
                 .where(
                         usersProblemEntity.ref.user.userId.eq(userId),
-                        usersProblemEntity.solvedTime.between(startOfMonth, endOfMonth))
+                        usersProblemEntity.solvedTime.between(startOfMonth, endOfMonth),
+                        usersProblemEntity.solvedTime.notBetween(ignoreStart, ignoreEnd)
+                )
                 .groupBy(dateStr)
+                .orderBy(dateStr.asc())
                 .fetch();
     }
 

--- a/src/main/java/com/project/repository/MyPageRepository.java
+++ b/src/main/java/com/project/repository/MyPageRepository.java
@@ -3,6 +3,7 @@ package com.project.repository;
 import com.project.dto.response.GrassResponse;
 import com.project.dto.response.ProblemResponse;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -45,7 +46,7 @@ public class MyPageRepository {
                 .where(
                         usersProblemEntity.ref.user.userId.eq(userId),
                         usersProblemEntity.solvedTime.between(startOfMonth, endOfMonth),
-                        usersProblemEntity.solvedTime.notBetween(ignoreStart, ignoreEnd)
+                        ignoreBatchTime(ignoreStart, ignoreEnd)
                 )
                 .groupBy(dateStr)
                 .orderBy(dateStr.asc())
@@ -70,10 +71,16 @@ public class MyPageRepository {
                         usersProblemEntity.ref.user.userId.eq(userId),
                         usersProblemEntity.isSolved.isTrue(),
                         usersProblemEntity.solvedTime.between(startOfDay, endOfDay),
-                        usersProblemEntity.solvedTime.notBetween(ignoreStart, ignoreEnd)
+                        ignoreBatchTime(ignoreStart, ignoreEnd)
                 )
                 .orderBy(usersProblemEntity.solvedTime.asc())
                 .fetch();
+    }
+    private BooleanExpression ignoreBatchTime(LocalDateTime start, LocalDateTime end) {
+        if (start == null || end == null) {
+            return null; // QueryDSL에서 null을 반환하면 Where 절에서 자동으로 제거됨
+        }
+        return usersProblemEntity.solvedTime.notBetween(start, end);
     }
 
 }

--- a/src/main/java/com/project/service/MyPageService.java
+++ b/src/main/java/com/project/service/MyPageService.java
@@ -37,15 +37,14 @@ public class MyPageService {
                         .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 제외할 시간대 계산 (가입 직후 첫 배치 시간)
-        // 가입: 13:30 -> 제외 범위 : 14:00:00 ~ 14:59:59 -> 15:00
         LocalDateTime createdAt = user.getCreatedAt();
-        LocalDateTime ignoreStart = createdAt.plusHours(1).withMinute(0).withSecond(0).withNano(0);
-        LocalDateTime ignoreEnd = ignoreStart.withMinute(59).withSecond(59).withNano(999_999_999);
+        //배치 도는 유효한 시간
+        LocalDateTime validAfter = createdAt.withMinute(0).withSecond(0).withNano(0).plusHours(2);
 
-        // 2. 리포지토리에 제외할 시간 범위 (ignoreStart, ignoreEnd)
-        // Repository에서 solvedTime.notBetween(ignoreStart, ignoreEnd) 처리를 수행
+
+        // 2. 잔디 데이터 조회 (validAfter 이상인 데이터만 조회)
         List<GrassResponse> grassList = myPageRepository.findGrassList(
-                userId, year, month, ignoreStart, ignoreEnd
+                userId, year, month, validAfter
         );
 
         // 상세 조회 할 날짜 결정
@@ -53,7 +52,7 @@ public class MyPageService {
 
         // 상세: 일간 문제 목록 조회 (푼 시간 정렬)
         List<ProblemResponse> problemList =
-                myPageRepository.findSolvedProblemList(userId, targetDate, ignoreStart, ignoreEnd);
+                myPageRepository.findSolvedProblemList(userId, targetDate, validAfter);
 
         // 5. 통계 계산
         MyPageMapper.DailyStatistics dailyStats = calculateDailyStatistics(problemList, targetDate);

--- a/src/main/java/com/project/service/MyPageService.java
+++ b/src/main/java/com/project/service/MyPageService.java
@@ -53,7 +53,7 @@ public class MyPageService {
 
         // 상세: 일간 문제 목록 조회 (푼 시간 정렬)
         List<ProblemResponse> problemList =
-                myPageRepository.findSolvedProblemList(userId, targetDate, ignoreStart,ignoreEnd);
+                myPageRepository.findSolvedProblemList(userId, targetDate, ignoreStart, ignoreEnd);
 
         // 5. 통계 계산
         MyPageMapper.DailyStatistics dailyStats = calculateDailyStatistics(problemList, targetDate);

--- a/src/main/java/com/project/service/MyPageService.java
+++ b/src/main/java/com/project/service/MyPageService.java
@@ -37,10 +37,10 @@ public class MyPageService {
                         .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 제외할 시간대 계산 (가입 직후 첫 배치 시간)
-        // 가입: 13:30 -> 제외 범위 : 14:00:00 ~ 14:59:59
+        // 가입: 13:30 -> 제외 범위 : 14:00:00 ~ 14:59:59 -> 15:00
         LocalDateTime createdAt = user.getCreatedAt();
         LocalDateTime ignoreStart = createdAt.plusHours(1).withMinute(0).withSecond(0).withNano(0);
-        LocalDateTime ignoreEnd = ignoreStart.withMinute(59).withSecond(59);
+        LocalDateTime ignoreEnd = ignoreStart.withMinute(59).withSecond(59).withNano(999_999_999);
 
         // 2. 리포지토리에 제외할 시간 범위 (ignoreStart, ignoreEnd)
         // Repository에서 solvedTime.notBetween(ignoreStart, ignoreEnd) 처리를 수행
@@ -53,7 +53,7 @@ public class MyPageService {
 
         // 상세: 일간 문제 목록 조회 (푼 시간 정렬)
         List<ProblemResponse> problemList =
-                myPageRepository.findSolvedProblemList(userId, targetDate);
+                myPageRepository.findSolvedProblemList(userId, targetDate, ignoreStart,ignoreEnd);
 
         // 5. 통계 계산
         MyPageMapper.DailyStatistics dailyStats = calculateDailyStatistics(problemList, targetDate);

--- a/src/test/java/com/project/repository/MyPageRepositoryTest.java
+++ b/src/test/java/com/project/repository/MyPageRepositoryTest.java
@@ -107,8 +107,6 @@ class MyPageRepositoryTest {
         int year = 2025;
         int month = 12;
 
-        // setUp에서 10:00 , 14:00 15:00 데이터 넣음
-        // 가입 직후 14:00-14:59에 배치가 돌았을때 가정
         LocalDateTime ignoreStart = LocalDateTime.of(2025, 12, 5, 10, 0, 0);
         LocalDateTime ignoreEnd = LocalDateTime.of(2025, 12, 5, 10, 59, 59);
 

--- a/src/test/java/com/project/repository/MyPageRepositoryTest.java
+++ b/src/test/java/com/project/repository/MyPageRepositoryTest.java
@@ -130,10 +130,12 @@ class MyPageRepositoryTest {
     void findSolvedProblemListTest() {
         // given
         LocalDate date = LocalDate.of(2025, 12, 5);
+        LocalDateTime ignoreStart = LocalDateTime.of(2025, 12, 5, 10, 0, 0);
+        LocalDateTime ignoreEnd = LocalDateTime.of(2025, 12, 5, 10, 59, 59);
 
         // when
         List<ProblemResponse> result =
-                myPageRepository.findSolvedProblemList(user.getUserId(), date);
+                myPageRepository.findSolvedProblemList(user.getUserId(), date, ignoreStart, ignoreEnd);
 
         // then
         assertThat(result).hasSize(5);

--- a/src/test/java/com/project/service/MyPageServiceTest.java
+++ b/src/test/java/com/project/service/MyPageServiceTest.java
@@ -105,7 +105,7 @@ class MyPageServiceTest {
 
         UserEntity mockUser = UserEntity.builder().userId(userId).createdAt(createdAt).totalSolvedCount(0).build();
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
-        given(myPageRepository.findSolvedProblemList(userId, targetDate)).willReturn(Collections.emptyList());
+        given(myPageRepository.findSolvedProblemList(userId, targetDate, any(), any())).willReturn(Collections.emptyList());
 
         ReflectionTestUtils.setField(mockUser, "createdAt", createdAt);
 
@@ -155,7 +155,7 @@ class MyPageServiceTest {
 
         ReflectionTestUtils.setField(mockUser, "createdAt", createdAt);
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
-        given(myPageRepository.findSolvedProblemList(any(), any())).willReturn(Collections.emptyList());
+        given(myPageRepository.findSolvedProblemList(any(), any(), any(), any())).willReturn(Collections.emptyList());
 
         // [변경] 파라미터 개수 6개로 맞춤
         given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList()))
@@ -188,7 +188,7 @@ class MyPageServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt(), any(), any()))
                 .willReturn(Collections.emptyList());
-        given(myPageRepository.findSolvedProblemList(any(), any())).willReturn(Collections.emptyList());
+        given(myPageRepository.findSolvedProblemList(any(), any(), any(), any())).willReturn(Collections.emptyList());
         given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList()))
                 .willReturn(mock(MyPageResponse.class));
 
@@ -198,7 +198,7 @@ class MyPageServiceTest {
         // then
         // 예상: 13:30 가입 -> 14:00:00 ~ 14:59:59 제외
         LocalDateTime expectedStart = LocalDateTime.of(2025, 12, 1, 14, 0, 0);
-        LocalDateTime expectedEnd = LocalDateTime.of(2025, 12, 1, 14, 59, 59);
+        LocalDateTime expectedEnd = LocalDateTime.of(2025, 12, 1, 14, 59, 59,999_999_999);
 
         verify(myPageRepository).findGrassList(
                 eq(userId),
@@ -215,7 +215,7 @@ class MyPageServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt(), any(), any()))
                 .willReturn(Collections.emptyList());
-        given(myPageRepository.findSolvedProblemList(userId, targetDate))
+        given(myPageRepository.findSolvedProblemList(userId, targetDate, any(), any()))
                 .willReturn(mockProblems);
         given(rankingDayRepository.calculateDailyRank(anyInt(), any(), any()))
                 .willReturn(1L);

--- a/src/test/java/com/project/service/MyPageServiceTest.java
+++ b/src/test/java/com/project/service/MyPageServiceTest.java
@@ -170,7 +170,7 @@ class MyPageServiceTest {
     private void setupSuccessMocks(Long userId, LocalDate targetDate,
             UserEntity mockUser, List<ProblemResponse> mockProblems) {
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
-        given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt()))
+        given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt(), any(), any()))
                 .willReturn(Collections.emptyList());
         given(myPageRepository.findSolvedProblemList(userId, targetDate))
                 .willReturn(mockProblems);

--- a/src/test/java/com/project/service/MyPageServiceTest.java
+++ b/src/test/java/com/project/service/MyPageServiceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -59,6 +59,7 @@ class MyPageServiceTest {
         Long userId = 1L;
         String dateStr = "2025-12-05";
         LocalDate targetDate = LocalDate.parse(dateStr);
+        LocalDateTime createdAt = LocalDateTime.of(2025, 1, 1, 10, 0);
 
         // 1. Mock 데이터 생성
         UserEntity mockUser = UserEntity.builder().userId(userId).totalSolvedCount(100).build();
@@ -66,6 +67,7 @@ class MyPageServiceTest {
                 new ProblemResponse("A", 5, "url1"),
                 new ProblemResponse("B", 10, "url2")
         );
+        ReflectionTestUtils.setField(mockUser, "createdAt", createdAt);
 
         // 2. Mock 동작 설정 (Checkstyle 메서드 길이 제한을 위해 헬퍼 메서드로 분리)
         setupSuccessMocks(userId, targetDate, mockUser, mockProblems);
@@ -104,6 +106,8 @@ class MyPageServiceTest {
         UserEntity mockUser = UserEntity.builder().userId(userId).createdAt(createdAt).totalSolvedCount(0).build();
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(myPageRepository.findSolvedProblemList(userId, targetDate)).willReturn(Collections.emptyList());
+
+        ReflectionTestUtils.setField(mockUser, "createdAt", createdAt);
 
         // [변경] Mapper 파라미터가 6개로 줄어듦 (DailyStatistics 포함)
         given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList()))
@@ -149,6 +153,7 @@ class MyPageServiceTest {
         LocalDateTime createdAt = LocalDateTime.of(2025, 1, 1, 10, 0);
         UserEntity mockUser = UserEntity.builder().userId(userId).createdAt(createdAt).build();
 
+        ReflectionTestUtils.setField(mockUser, "createdAt", createdAt);
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(myPageRepository.findSolvedProblemList(any(), any())).willReturn(Collections.emptyList());
 
@@ -179,7 +184,7 @@ class MyPageServiceTest {
                 .userId(userId)
                 .createdAt(signUpTime) // [수정] 가입일 설정
                 .build();
-
+        ReflectionTestUtils.setField(mockUser, "createdAt", signUpTime);
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt(), any(), any()))
                 .willReturn(Collections.emptyList());

--- a/src/test/java/com/project/service/MyPageServiceTest.java
+++ b/src/test/java/com/project/service/MyPageServiceTest.java
@@ -61,12 +61,12 @@ class MyPageServiceTest {
         Long userId = 1L;
         String dateStr = "2025-12-05";
         LocalDate targetDate = LocalDate.parse(dateStr);
-        LocalDateTime createdAt = LocalDateTime.of(2025, 1, 1, 13, 0,0);
+        LocalDateTime createAt = LocalDateTime.of(2025, 1, 1, 13, 0, 0);
 
         // 1. Mock 데이터 생성
         UserEntity mockUser = UserEntity.builder().userId(userId).totalSolvedCount(100).build();
         List<ProblemResponse> mockProblems = List.of(new ProblemResponse("A", 5, "url1"), new ProblemResponse("B", 10, "url2"));
-        ReflectionTestUtils.setField(mockUser, "createdAt", createdAt);
+        ReflectionTestUtils.setField(mockUser, "createdAt", createAt);
 
         // 2. Mock 동작 설정
         setupSuccessMocks(userId, targetDate, mockUser, mockProblems);

--- a/src/test/java/com/project/service/MyPageServiceTest.java
+++ b/src/test/java/com/project/service/MyPageServiceTest.java
@@ -65,10 +65,7 @@ class MyPageServiceTest {
 
         // 1. Mock 데이터 생성
         UserEntity mockUser = UserEntity.builder().userId(userId).totalSolvedCount(100).build();
-        List<ProblemResponse> mockProblems = List.of(
-                new ProblemResponse("A", 5, "url1"),
-                new ProblemResponse("B", 10, "url2")
-        );
+        List<ProblemResponse> mockProblems = List.of(new ProblemResponse("A", 5, "url1"), new ProblemResponse("B", 10, "url2"));
         ReflectionTestUtils.setField(mockUser, "createdAt", createdAt);
 
         // 2. Mock 동작 설정
@@ -83,17 +80,14 @@ class MyPageServiceTest {
         // 5 + 10 = 15점, 1등, 2문제, 최대난이도 10
         MyPageMapper.DailyStatistics expectedStats = new MyPageMapper.DailyStatistics(15, 1, 2, 10);
 
-        verify(myPageMapper).toResponse(
-                eq(mockUser),
-                eq(100),                // totalSolvedCount
+        verify(myPageMapper).toResponse(eq(mockUser), eq(100),                // totalSolvedCount
                 anyList(),              // grassList
                 eq(targetDate),         // date
                 eq(expectedStats),      // 통계 객체 검증
                 eq(mockProblems)        // problemList
         );
 
-        verify(rankingDayRepository, times(1))
-                .calculateDailyRank(eq(15), any(LocalDateTime.class), any(LocalDateTime.class));
+        verify(rankingDayRepository, times(1)).calculateDailyRank(eq(15), any(LocalDateTime.class), any(LocalDateTime.class));
     }
 
     @Test
@@ -110,11 +104,9 @@ class MyPageServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
 
         // ignoreStart/End 대신 any() 사용
-        given(myPageRepository.findSolvedProblemList(eq(userId), eq(targetDate), any(), any()))
-                .willReturn(Collections.emptyList());
+        given(myPageRepository.findSolvedProblemList(eq(userId), eq(targetDate), any(), any())).willReturn(Collections.emptyList());
 
-        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList()))
-                .willReturn(mock(MyPageResponse.class));
+        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList())).willReturn(mock(MyPageResponse.class));
 
         // when
         myPageService.getMyPage(userId, 2025, 12, "2025-12-05");
@@ -122,14 +114,7 @@ class MyPageServiceTest {
         // then
         MyPageMapper.DailyStatistics zeroStats = new MyPageMapper.DailyStatistics(0, 0, 0, 0);
 
-        verify(myPageMapper).toResponse(
-                eq(mockUser),
-                eq(0),
-                anyList(),
-                eq(targetDate),
-                eq(zeroStats),
-                eq(Collections.emptyList())
-        );
+        verify(myPageMapper).toResponse(eq(mockUser), eq(0), anyList(), eq(targetDate), eq(zeroStats), eq(Collections.emptyList()));
 
         verify(rankingDayRepository, never()).calculateDailyRank(anyInt(), any(), any());
     }
@@ -142,9 +127,7 @@ class MyPageServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> myPageService.getMyPage(userId, 2025, 12, "2025-12-05"))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        assertThatThrownBy(() -> myPageService.getMyPage(userId, 2025, 12, "2025-12-05")).isInstanceOf(BusinessException.class).hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }
 
     @Test
@@ -159,22 +142,16 @@ class MyPageServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
 
         // ignoreStart, ignoreEnd 대신 any() 사용
-        given(myPageRepository.findSolvedProblemList(any(), any(), any(), any()))
-                .willReturn(Collections.emptyList());
+        given(myPageRepository.findSolvedProblemList(any(), any(), any(), any())).willReturn(Collections.emptyList());
 
-        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList()))
-                .willReturn(mock(MyPageResponse.class));
+        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList())).willReturn(mock(MyPageResponse.class));
 
         // when
         myPageService.getMyPage(userId, 2020, 1, null);
 
         // then
-        verify(myPageMapper).toResponse(
-                any(), anyInt(), anyList(),
-                eq(LocalDate.of(2020, 1, 1)), // 기대값
-                any(),
-                anyList()
-        );
+        verify(myPageMapper).toResponse(any(), anyInt(), anyList(), eq(LocalDate.of(2020, 1, 1)), // 기대값
+                any(), anyList());
     }
 
     @Test
@@ -185,20 +162,15 @@ class MyPageServiceTest {
         // 시나리오: 13:30:45 가입
         LocalDateTime signUpTime = LocalDateTime.of(2025, 12, 1, 13, 30, 45);
 
-        UserEntity mockUser = UserEntity.builder()
-                .userId(userId)
-                .build();
+        UserEntity mockUser = UserEntity.builder().userId(userId).build();
         ReflectionTestUtils.setField(mockUser, "createdAt", signUpTime);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
 
         // Mocking: any()를 사용하여 어떤 시간이 들어오든 에러가 안 나게 설정
-        given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt(), any(), any()))
-                .willReturn(Collections.emptyList());
-        given(myPageRepository.findSolvedProblemList(any(), any(), any(), any()))
-                .willReturn(Collections.emptyList());
-        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList()))
-                .willReturn(mock(MyPageResponse.class));
+        given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt(), any(), any())).willReturn(Collections.emptyList());
+        given(myPageRepository.findSolvedProblemList(any(), any(), any(), any())).willReturn(Collections.emptyList());
+        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(), anyList())).willReturn(mock(MyPageResponse.class));
 
         // when
         myPageService.getMyPage(userId, 2025, 12, "2025-12-05");
@@ -210,36 +182,20 @@ class MyPageServiceTest {
         LocalDateTime expectedEnd = LocalDateTime.of(2025, 12, 1, 14, 59, 59, 999_999_999);
 
         // [핵심 검증] Service가 계산한 시간이 정확한지 Repository 호출 인자 확인
-        verify(myPageRepository).findGrassList(
-                eq(userId),
-                eq(2025),
-                eq(12),
-                eq(expectedStart),
-                eq(expectedEnd)
-        );
+        verify(myPageRepository).findGrassList(eq(userId), eq(2025), eq(12), eq(expectedStart), eq(expectedEnd));
 
         // 상세 목록 조회에도 동일한 필터링이 적용되는지 확인
-        verify(myPageRepository).findSolvedProblemList(
-                eq(userId),
-                any(LocalDate.class),
-                eq(expectedStart),
-                eq(expectedEnd)
-        );
+        verify(myPageRepository).findSolvedProblemList(eq(userId), any(LocalDate.class), eq(expectedStart), eq(expectedEnd));
     }
 
-    private void setupSuccessMocks(Long userId, LocalDate targetDate,
-            UserEntity mockUser, List<ProblemResponse> mockProblems) {
+    private void setupSuccessMocks(Long userId, LocalDate targetDate, UserEntity mockUser, List<ProblemResponse> mockProblems) {
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
 
-        given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt(), any(), any()))
-                .willReturn(Collections.emptyList());
-        given(myPageRepository.findSolvedProblemList(eq(userId), eq(targetDate), any(), any()))
-                .willReturn(mockProblems);
+        given(myPageRepository.findGrassList(anyLong(), anyInt(), anyInt(), any(), any())).willReturn(Collections.emptyList());
+        given(myPageRepository.findSolvedProblemList(eq(userId), eq(targetDate), any(), any())).willReturn(mockProblems);
 
-        given(rankingDayRepository.calculateDailyRank(anyInt(), any(), any()))
-                .willReturn(1L);
+        given(rankingDayRepository.calculateDailyRank(anyInt(), any(), any())).willReturn(1L);
 
-        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(MyPageMapper.DailyStatistics.class), anyList()))
-                .willReturn(mock(MyPageResponse.class));
+        given(myPageMapper.toResponse(any(), anyInt(), anyList(), any(), any(MyPageMapper.DailyStatistics.class), anyList())).willReturn(mock(MyPageResponse.class));
     }
 }


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- #이슈번호
#45 
---

## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
회원가입 직후 실행되는 첫 번째 정각 배치(Batch) 시점에, 과거 풀이 이력이 현재 시간(solved_time)으로 일괄 저장되어 마이페이지 잔디(Daily Stats)가 비정상적으로 높게 집계되는 문제를 해결했습니다.

## 🛠️ 변경 사항
1. Service 로직 개선 (MyPageService)

1차: 사용자의 가입 시간(created_at)을 기준으로 초기 배치가 실행되는 타겟 시간대를 계산하는 로직을 추가했습니다.
계산 방식: 가입 시간 + 1시간의 정각 ~ 59분 59초
Ex) 13:30 가입 → 14:00:00 ~ 14:59:59 (제외 대상)

### 변경: 가입 시간의 시 정각 기준 + 2시간 이후의 데이터만 유효한 것으로 간주 
Ex) 13:30 가입 → 15:00:00 이후에 풀이된 문제만 조회


2. Repository QueryDSL 수정 (MyPageRepository)

1차: findGrassList 메서드에 제외할 시간 범위(ignoreStart, ignoreEnd) 파라미터를 추가했습니다.
where 절에 .notBetween(ignoreStart, ignoreEnd) 조건을 추가하여, 해당 시간대에 적재된 대량의 초기 데이터를 집계에서 제외했습니다.

### 변경: goe(validAfter) 사용 

3. 테스트 코드 추가 및 수정
RepositoryTest: findGrassList 파라미터 변경에 따른 테스트 수정 및 필터링 검증 테스트 추가.
ServiceTest: 가입 시간에 따라 제외 시간대가 정확히 계산되어 Repository로 전달되는지 검증.
---

## ⌨ 기타
