### PR TITLE
feat: 버그수정, 신규유저, 업데이트 시각 쿼리 추가

### DIFF
--- a/src/main/java/com/project/common/exception/ErrorCode.java
+++ b/src/main/java/com/project/common/exception/ErrorCode.java
@@ -39,7 +39,8 @@ public enum ErrorCode {
     // Ranking
     INVALID_RANKING_PERIOD(HttpStatus.BAD_REQUEST, "RANK_002", "Invalid ranking period"),
     INVALID_RANKING_GROUP(HttpStatus.BAD_REQUEST, "RANK_003", "Invalid ranking group"),
-    INVALID_RANKING_PAGINATION(HttpStatus.BAD_REQUEST, "RANK_004", "Invalid ranking pagination");
+    INVALID_RANKING_PAGINATION(HttpStatus.BAD_REQUEST, "RANK_004", "Invalid ranking pagination"),
+    RANKING_SNAPSHOT_NOT_READY(HttpStatus.TOO_EARLY, "RANK_005", "Ranking snapshot not ready");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/project/common/util/RankUtil.java
+++ b/src/main/java/com/project/common/util/RankUtil.java
@@ -99,7 +99,7 @@ public class RankUtil {
      * DB에 utc로 저장되어 있기 때문에 kst 시간대로 변환 후 절삭
      */
     public static LocalDateTime utcToKst(LocalDateTime utc) {
-        if(utc == null) {
+        if (utc == null) {
             return null;
         }
         return resolveBaseTime(utc).plusHours(9);

--- a/src/main/java/com/project/common/util/RankUtil.java
+++ b/src/main/java/com/project/common/util/RankUtil.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
  */
 public class RankUtil {
 
-
     /**
      * 정각으로 절삭 하는 유틸 함수, 배치 시간 텀에 따라 유동적 변경
      * @param baseTime
@@ -25,6 +24,7 @@ public class RankUtil {
 
     /**
      * period에 따른 집계 시작 시각 계산
+     * 현재, 과거 상관 없이 사용자의 요청 시각에 따라 반환
      *  return 값
      *  - day   : 해당 날짜의 00:00
      *  - week  : 해당 주 월요일 00:00
@@ -32,7 +32,7 @@ public class RankUtil {
      */
     public static LocalDateTime getPeriodStart(String period, LocalDateTime baseTime) {
 
-        LocalDateTime t = resolveBaseTime(baseTime);
+        LocalDateTime t = resolveBaseTime(baseTime); // 중복 코드
 
         return switch (period) {
             case "week" -> t
@@ -48,11 +48,12 @@ public class RankUtil {
     }
 
     /**
-     * 요청한 기간에 따른 과거, 현재 비교해 해당 기간에 맞는 집계 마감 시각 계산
+     * period에 따른 집계 마감 지점 선정
      * @param period
      * @param requested
      * @param now
      * @return 집계 마감 시각(정각)
+     * version : 1.0.0
      */
     public static LocalDateTime getPeriodEndInclusive(String period, LocalDateTime requested, LocalDateTime now) {
         LocalDateTime req = resolveBaseTime(requested);
@@ -63,15 +64,44 @@ public class RankUtil {
 
         boolean isCurrentPeriod = reqStart.equals(curStart);
 
+        // 현재 구간
         if (isCurrentPeriod) {
             return cur;
         }
 
+        // 과거 구간
         return switch (period) {
             case "week" -> reqStart.plusWeeks(1);
             case "month" -> reqStart.plusMonths(1);
             case "day" -> reqStart.plusDays(1);
             default -> throw new IllegalArgumentException("invalid period: " + period);
         };
+    }
+
+
+    /**
+     * period에 따른 집계 마감 지점 선정
+     * version : 1.0.1
+     */
+    public static LocalDateTime getPeriodEndBoundary(String period, LocalDateTime periodStart) {
+        LocalDateTime start = resolveBaseTime(periodStart);
+
+        return switch (period) {
+            case "week" -> start.plusWeeks(1);
+            case "month" -> start.plusMonths(1);
+            case "day" -> start.plusDays(1);
+            default -> throw new IllegalArgumentException("invalid period: " + period);
+        };
+    }
+
+
+    /**
+     * DB에 utc로 저장되어 있기 때문에 kst 시간대로 변환 후 절삭
+     */
+    public static LocalDateTime utcToKst(LocalDateTime utc) {
+        if(utc == null) {
+            return null;
+        }
+        return resolveBaseTime(utc).plusHours(9);
     }
 }

--- a/src/main/java/com/project/controller/RankingController.java
+++ b/src/main/java/com/project/controller/RankingController.java
@@ -1,7 +1,7 @@
 package com.project.controller;
 
 import com.project.common.dto.ApiResponse;
-import com.project.dto.response.RankingPageResponse;
+import com.project.dto.response.RankingPageExtendedResponse;
 import com.project.service.RankingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,7 @@ public class RankingController {
    * @param size 페이지 크기 (default: 20)
    */
   @GetMapping
-  public ResponseEntity<ApiResponse<RankingPageResponse>> getRanking(
+  public ResponseEntity<ApiResponse<RankingPageExtendedResponse>> getRanking(
           @RequestParam(defaultValue = "day") String period,
           @RequestParam(required = false)
           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
@@ -42,7 +42,7 @@ public class RankingController {
           @RequestParam(defaultValue = "ALL") String group,
           @RequestParam(defaultValue = "1") int page,
           @RequestParam(defaultValue = "20") int size) {
-    RankingPageResponse response = rankingService.getRankingForBatch(period, dateTime, group, page, size);
+    RankingPageExtendedResponse response = rankingService.getRankingForBatch(period, dateTime, group, page, size);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/project/controller/RankingController.java
+++ b/src/main/java/com/project/controller/RankingController.java
@@ -42,7 +42,7 @@ public class RankingController {
           @RequestParam(defaultValue = "ALL") String group,
           @RequestParam(defaultValue = "1") int page,
           @RequestParam(defaultValue = "20") int size) {
-    RankingPageResponse response = rankingService.getRanking(period, dateTime, group, page, size);
+    RankingPageResponse response = rankingService.getRankingForBatch(period, dateTime, group, page, size);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/project/dto/response/RankingPageExtendedResponse.java
+++ b/src/main/java/com/project/dto/response/RankingPageExtendedResponse.java
@@ -1,0 +1,18 @@
+package com.project.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * author : 박준희
+ */
+@Getter
+@AllArgsConstructor
+public class RankingPageExtendedResponse {
+    private boolean hasNext;
+    private LocalDateTime updateTime;
+    private List<RankingRowExtendedResponse> rows;
+}

--- a/src/main/java/com/project/dto/response/RankingRowExtendedResponse.java
+++ b/src/main/java/com/project/dto/response/RankingRowExtendedResponse.java
@@ -20,8 +20,6 @@ public class RankingRowExtendedResponse {
     private String baekjoonId;
     private String team;
     private int diff;
-
-    // 신규유저
     private boolean newUser;
 
     public RankingRowExtendedResponse(Long userId, String name, int tier, int totalScore, long solvedCount, String baekjoonId, String team, boolean newUser) {

--- a/src/main/java/com/project/dto/response/RankingRowExtendedResponse.java
+++ b/src/main/java/com/project/dto/response/RankingRowExtendedResponse.java
@@ -1,14 +1,14 @@
 package com.project.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 /**
  * author : 박준희
  */
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
 public class RankingRowExtendedResponse {
     private Long userId;
@@ -22,16 +22,22 @@ public class RankingRowExtendedResponse {
     private int diff;
     private boolean newUser;
 
-    public RankingRowExtendedResponse(Long userId, String name, int tier, int totalScore, long solvedCount, String baekjoonId, String team, boolean newUser) {
-        this.userId = userId;
-        this.name = name;
-        this.tier = tier;
-        this.totalScore = totalScore;
-        this.solvedCount = solvedCount;
-        this.baekjoonId = baekjoonId;
-        this.team = team;
-        this.rank = 0;
-        this.diff = 0;
+    private RankingRowExtendedResponse(RankingRowResponse base, boolean newUser) {
+        Objects.requireNonNull(base, "base must not be null");
+
+        this.userId = base.getUserId();
+        this.rank = base.getRank();
+        this.tier = base.getTier();
+        this.name = base.getName();
+        this.totalScore = base.getTotalScore();
+        this.solvedCount = base.getSolvedCount();
+        this.baekjoonId = base.getBaekjoonId();
+        this.team = base.getTeam();
+        this.diff = base.getDiff();
         this.newUser = newUser;
+    }
+
+    public static RankingRowExtendedResponse from(RankingRowResponse base, boolean newUser) {
+        return new RankingRowExtendedResponse(base, newUser);
     }
 }

--- a/src/main/java/com/project/dto/response/RankingRowExtendedResponse.java
+++ b/src/main/java/com/project/dto/response/RankingRowExtendedResponse.java
@@ -1,0 +1,39 @@
+package com.project.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * author : 박준희
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RankingRowExtendedResponse {
+    private Long userId;
+    private int rank;
+    private int tier;
+    private String name;
+    private int totalScore;
+    private long solvedCount;
+    private String baekjoonId;
+    private String team;
+    private int diff;
+
+    // 신규유저
+    private boolean newUser;
+
+    public RankingRowExtendedResponse(Long userId, String name, int tier, int totalScore, long solvedCount, String baekjoonId, String team, boolean newUser) {
+        this.userId = userId;
+        this.name = name;
+        this.tier = tier;
+        this.totalScore = totalScore;
+        this.solvedCount = solvedCount;
+        this.baekjoonId = baekjoonId;
+        this.team = team;
+        this.rank = 0;
+        this.diff = 0;
+        this.newUser = newUser;
+    }
+}

--- a/src/main/java/com/project/repository/BatchMetaRepository.java
+++ b/src/main/java/com/project/repository/BatchMetaRepository.java
@@ -1,0 +1,39 @@
+package com.project.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class BatchMetaRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /*==========================
+    * @author : 박준희
+    * 배치 스냅샷 테이블에서 가장 최신 스냅샷 가져오기
+    * 현재 job이 하나만 있다고 생각하고 작성한 쿼리임
+    ==========================**/
+    public Optional<LocalDateTime> findLastCompletedEndTime() {
+        String sql = """
+            select bje.end_time
+            from batch_job_execution bje
+            where bje.status = 'COMPLETED'
+              and bje.end_time is not null
+            order by bje.end_time desc, bje.job_execution_id desc
+            limit 1
+            """;
+
+        return jdbcTemplate.query(sql, rs -> {
+            if(!rs.next()) {
+                return Optional.empty();
+            }
+          LocalDateTime endTime =  rs.getObject(1, LocalDateTime.class);
+            return Optional.ofNullable(endTime);
+        });
+    }
+}

--- a/src/main/java/com/project/repository/BatchMetaRepository.java
+++ b/src/main/java/com/project/repository/BatchMetaRepository.java
@@ -29,7 +29,7 @@ public class BatchMetaRepository {
             """;
 
         return jdbcTemplate.query(sql, rs -> {
-            if(!rs.next()) {
+            if (!rs.next()) {
                 return Optional.empty();
             }
           LocalDateTime endTime =  rs.getObject(1, LocalDateTime.class);

--- a/src/main/java/com/project/repository/RankingQueryRepository.java
+++ b/src/main/java/com/project/repository/RankingQueryRepository.java
@@ -28,11 +28,11 @@ public class RankingQueryRepository {
     /**
      * 시작 구간 ~ 마감 기간과 그룹에 따른 데이터 집계
      * @param start
-     * @param endExclusive
+     * @param endInclusive
      * @param team
      * @return 총 점수를 인덱스로 하는 랭킹 리스트 반환
      */
-  public List<RankingRowResponse> getRankingRows(LocalDateTime start, LocalDateTime endExclusive, EurekaTeamName team) {
+  public List<RankingRowResponse> getRankingRows(LocalDateTime start, LocalDateTime endInclusive, EurekaTeamName team) {
     QUsersProblemEntity usersProblemEntity = QUsersProblemEntity.usersProblemEntity;
     QUserEntity userEntity = QUserEntity.userEntity;
     QProblemEntity problemEntity = QProblemEntity.problemEntity;
@@ -59,7 +59,7 @@ public class RankingQueryRepository {
             .join(usersProblemEntity.ref.problem, problemEntity)
             .where(
                     usersProblemEntity.solvedTime.gt(start),
-                    usersProblemEntity.solvedTime.loe(endExclusive),
+                    usersProblemEntity.solvedTime.loe(endInclusive),
                     usersProblemEntity.solvedTime.goe(validAfterExpr),
                     teamFilter(team, userEntity)
             )

--- a/src/main/java/com/project/repository/RankingQueryRepository.java
+++ b/src/main/java/com/project/repository/RankingQueryRepository.java
@@ -11,6 +11,7 @@ import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -21,6 +22,7 @@ import java.util.List;
  */
 @Repository
 @RequiredArgsConstructor
+@Slf4j
 public class RankingQueryRepository {
 
   private final JPAQueryFactory queryFactory;
@@ -44,31 +46,39 @@ public class RankingQueryRepository {
                       userEntity.createdAt
               );
 
-   return queryFactory
-            .select(Projections.constructor(RankingRowResponse.class,
-                    userEntity.userId,
-                    userEntity.username,
-                    userEntity.bojTier,
-                    problemEntity.problemLevel.sum().as("totalScore"),
-                    problemEntity.problemLevel.count().as("solvedCount"),
-                    userEntity.baekjoonId,
-                    userEntity.teamName.stringValue()
-            ))
-            .from(usersProblemEntity)
-            .join(usersProblemEntity.ref.user, userEntity)
-            .join(usersProblemEntity.ref.problem, problemEntity)
-            .where(
-                    usersProblemEntity.solvedTime.gt(start),
-                    usersProblemEntity.solvedTime.loe(endInclusive),
-                    usersProblemEntity.solvedTime.goe(validAfterExpr),
-                    teamFilter(team, userEntity)
-            )
-            .groupBy(userEntity.userId)
-            .orderBy(
-                    problemEntity.problemLevel.sum().desc(),
-                    userEntity.username.asc()
-            )
-            .fetch();
+      // 쿼리 성능 확인
+      long t0 = System.nanoTime();
+      log.info("[랭킹 쿼리 시작] start={}, endInclusive={}, team={}", start, endInclusive, team);
+
+      List<RankingRowResponse> result = queryFactory
+              .select(Projections.constructor(RankingRowResponse.class,
+                      userEntity.userId,
+                      userEntity.username,
+                      userEntity.bojTier,
+                      problemEntity.problemLevel.sum().as("totalScore"),
+                      problemEntity.problemLevel.count().as("solvedCount"),
+                      userEntity.baekjoonId,
+                      userEntity.teamName.stringValue()
+              ))
+              .from(usersProblemEntity)
+              .join(usersProblemEntity.ref.user, userEntity)
+              .join(usersProblemEntity.ref.problem, problemEntity)
+              .where(
+                      usersProblemEntity.solvedTime.gt(start),
+                      usersProblemEntity.solvedTime.loe(endInclusive),
+                      usersProblemEntity.solvedTime.goe(validAfterExpr),
+                      teamFilter(team, userEntity)
+              )
+              .groupBy(userEntity.userId)
+              .orderBy(
+                      problemEntity.problemLevel.sum().desc(),
+                      userEntity.username.asc()
+              )
+              .fetch();
+      long time = (System.nanoTime() - t0) / 1_000_000;
+      log.info("[랭킹 쿼리 종료]: time={}", time);
+
+      return result;
   }
 
   private Predicate teamFilter(EurekaTeamName team, QUserEntity userEntity) {

--- a/src/main/java/com/project/repository/UserMetaQueryRepository.java
+++ b/src/main/java/com/project/repository/UserMetaQueryRepository.java
@@ -1,0 +1,41 @@
+package com.project.repository;
+
+import com.project.entity.QUserEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * author : 박준희
+ * 신규 유저를 확인하는 쿼리 -> 가입시간, id를 반환
+ */
+@Repository
+@RequiredArgsConstructor
+public class UserMetaQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Map<Long, LocalDateTime> findCreatedAtMapByUserIds(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        QUserEntity u = QUserEntity.userEntity;
+
+        return queryFactory
+                .select(u.userId, u.createdAt)
+                .from(u)
+                .where(u.userId.in(userIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(u.userId),
+                        t -> t.get(u.createdAt)
+                ));
+    }
+}

--- a/src/main/java/com/project/service/RankingService.java
+++ b/src/main/java/com/project/service/RankingService.java
@@ -43,59 +43,74 @@ public class RankingService {
     EurekaTeamName team = parseAndValidateGroup(group);
     validatePagination(page, size);
 
-    // 배치 완료 최신 스냅샷(UTC -> KST 변화 후 절삭)
+    // 배치 최신 스냅샷(UTC -> KST 변화 후 절삭)
     LocalDateTime availableEnd = batchMetaRepository.findLastCompletedEndTime()
             .map(RankUtil::utcToKst)
             .orElseThrow(() -> new BusinessException(ErrorCode.RANKING_SNAPSHOT_NOT_READY));
 
-
+   // 사용자가 요청한 시각(절삭)
     LocalDateTime effective = (dateTime != null) ? dateTime : LocalDateTime.now(clock);
     LocalDateTime reqBaseTime = RankUtil.resolveBaseTime(effective);
 
+    log.info("[INFO] 사용자의 요청 시각 = {}", reqBaseTime);
+    log.info("[INFO] 최신 스냅샷 시각 = {}", availableEnd);
 
-    // 집계 시작 지점
+
+    // 요청 기간의 시작과 끝 경계 계산
     LocalDateTime periodStart = RankUtil.getPeriodStart(normalizedPeriod, reqBaseTime);
-
-    // 마감 경계 설정
     LocalDateTime periodEndBoundary = RankUtil.getPeriodEndBoundary(normalizedPeriod, periodStart);
 
-    // 현재의 경우 집계 마감 구간은 배치의 최신 스냅샷 범위로 설정
-    LocalDateTime currentEndInclusive = availableEnd.isBefore(periodEndBoundary)
+
+    // 실제 조회 가능한 end는 최근 스냅샷 or 요청 경계 값 중 좀 더 이른 값
+    LocalDateTime endInclusive = availableEnd.isBefore(periodEndBoundary)
             ? availableEnd
             : periodEndBoundary;
+
+    // 현재/과거 판단
+    boolean isCurrentPeriod = RankUtil.getPeriodStart(normalizedPeriod, availableEnd).equals(periodStart);
+
+    // === 과거 구간 : 1번 쿼리, 순위 변동 계산 x ===
+    if(!isCurrentPeriod) {
+      List<RankingRowResponse> rows = rankingQueryRepository.getRankingRows(periodStart, endInclusive, team);
+
+      if(rows.isEmpty()) {
+        return new RankingPageResponse(false, List.of());
+      }
+
+      calculateRanks(rows);
+      rows.forEach(r -> r.setDiff(0));
+
+      return paginate(rows, page, size);
+    }
+
+
+    // === 현재 구간 : 2번 쿼리, 순위 변동 계산 o ===
+    LocalDateTime currentEndInclusive = endInclusive;
     LocalDateTime prevEndInclusive = currentEndInclusive.minusHours(1);
 
 
-    // 집계 시작
+    // 현재 구간 집계 1번 쿼리
     List<RankingRowResponse> currentAll = rankingQueryRepository.getRankingRows(periodStart, currentEndInclusive, team);
 
     if (currentAll.isEmpty()) {
       return new RankingPageResponse(false, List.of());
     }
 
+    // 1시간 전 구간 집계 2번 쿼리
     List<RankingRowResponse> prevAll = rankingQueryRepository.getRankingRows(periodStart, prevEndInclusive, team);
 
     calculateRanks(currentAll);
     calculateRanks(prevAll);
     calculateDiff(currentAll, prevAll);
 
-    int fromIndex = Math.max(0, (page - 1) * size);
-    if (fromIndex >= currentAll.size()) {
-      return new RankingPageResponse(false, List.of());
-    }
-
-    int toIndex = Math.min(fromIndex + size, currentAll.size());
-    List<RankingRowResponse> pageRows = currentAll.subList(fromIndex, toIndex);
-    boolean hasNext = toIndex < currentAll.size();
-
-    return new RankingPageResponse(hasNext, pageRows);
+    return paginate(currentAll, page, size);
   }
-
 
 
   /**
    * 해당 시간대의 랭킹과 직전 시간대 랭킹을 비교하여 반환
    * @Param  사용자가 요청한 시간대 (예: 2025.10.12T14:21:29)
+   * 버그 시 해당 함수로 롤백
    */
   public RankingPageResponse getRanking(String period, LocalDateTime dateTime, String group, int page, int size) {
 
@@ -136,6 +151,22 @@ public class RankingService {
   }
 
 
+  // ===== 계산&유효성 검사 =====
+
+  // 페이징 처리
+  private RankingPageResponse paginate(List<RankingRowResponse> rows, int page, int size) {
+    int fromIndex = Math.max(0, (page - 1) * size);
+    if (fromIndex >= rows.size()) {
+      return new RankingPageResponse(false, List.of());
+    }
+
+    int toIndex = Math.min(fromIndex + size, rows.size());
+    List<RankingRowResponse> pageRows = rows.subList(fromIndex, toIndex);
+    boolean hasNext = toIndex < rows.size();
+    return new RankingPageResponse(hasNext, rows.subList(fromIndex, toIndex));
+  }
+
+
   // 기간 유효성 검증
   private String normalizeAndValidatePeriod(String period) {
     String p = (period == null) ? "day" : period.toLowerCase();
@@ -144,6 +175,7 @@ public class RankingService {
     }
     return p;
   }
+
 
   // 그룹 유효성 검증
   private EurekaTeamName parseAndValidateGroup(String group) {
@@ -156,6 +188,7 @@ public class RankingService {
       throw new BusinessException(ErrorCode.INVALID_RANKING_GROUP);
     }
   }
+
 
   // 페이징 유효성 검증
   private void validatePagination(int page, int size) {

--- a/src/test/java/com/project/common/util/RankUtilTest.java
+++ b/src/test/java/com/project/common/util/RankUtilTest.java
@@ -143,4 +143,56 @@ class RankUtilTest {
 
         assertThat(endExclusive).isEqualTo(LocalDateTime.of(2025, 12, 1, 0, 0));
     }
+
+    @Test
+    @DisplayName("getPeriodEndBoundary(day) - periodStart 기준 다음날 00:00 반환")
+    void getPeriodEndBoundary_day() {
+        // given
+        LocalDateTime periodStart = LocalDateTime.of(2025, 12, 11, 0, 0);
+
+        // when
+        LocalDateTime end = RankUtil.getPeriodEndBoundary("day", periodStart);
+
+        // then
+        assertThat(end).isEqualTo(LocalDateTime.of(2025, 12, 12, 0, 0));
+    }
+
+    @Test
+    @DisplayName("getPeriodEndBoundary(week) - periodStart 기준 +1주(다음주 월요일 00:00) 반환")
+    void getPeriodEndBoundary_week() {
+        // given (월요일 00:00로 잡는 게 가장 명확)
+        LocalDateTime periodStart = LocalDateTime.of(2025, 12, 8, 0, 0); // Monday
+
+        // when
+        LocalDateTime end = RankUtil.getPeriodEndBoundary("week", periodStart);
+
+        // then
+        assertThat(end).isEqualTo(LocalDateTime.of(2025, 12, 15, 0, 0));
+    }
+
+    @Test
+    @DisplayName("getPeriodEndBoundary(month) - periodStart 기준 다음달 1일 00:00 반환")
+    void getPeriodEndBoundary_month() {
+        // given
+        LocalDateTime periodStart = LocalDateTime.of(2025, 12, 1, 0, 0);
+
+        // when
+        LocalDateTime end = RankUtil.getPeriodEndBoundary("month", periodStart);
+
+        // then
+        assertThat(end).isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0));
+    }
+
+    @Test
+    @DisplayName("utcToKst - UTC를 KST로 +9시간 하고 정각으로 절삭한다")
+    void utcToKst_convertsAndFloorsToHour() {
+        // given: UTC 2025-12-11 14:37:45 -> KST 2025-12-11 23:00:00
+        LocalDateTime utc = LocalDateTime.of(2025, 12, 11, 14, 37, 45);
+
+        // when
+        LocalDateTime kst = RankUtil.utcToKst(utc);
+
+        // then
+        assertThat(kst).isEqualTo(LocalDateTime.of(2025, 12, 11, 23, 0, 0));
+    }
 }

--- a/src/test/java/com/project/controller/RankingControllerTest.java
+++ b/src/test/java/com/project/controller/RankingControllerTest.java
@@ -1,8 +1,8 @@
 package com.project.controller;
 
 
-import com.project.dto.response.RankingPageResponse;
-import com.project.dto.response.RankingRowResponse;
+import com.project.dto.response.RankingPageExtendedResponse;
+import com.project.dto.response.RankingRowExtendedResponse;
 import com.project.service.RankingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -43,14 +43,11 @@ class RankingControllerTest {
     RankingService rankingService;
 
     @Test
-    @DisplayName("쿼리 파라미터 없으면 기본값(period=day, group=ALL, page=1, size=20)과 null dateTime이 서비스에 전달된다")
+    @DisplayName("쿼리 파라미터 없으면 기본값이 전달")
     void getRanking_usesDefaultParams_whenNoQueryParams() throws Exception {
         // given
-        RankingPageResponse dummyResponse =
-                new RankingPageResponse(false, Collections.emptyList());
-
-        given(rankingService.getRanking(anyString(), any(), anyString(), anyInt(), anyInt()))
-                .willReturn(dummyResponse);
+        given(rankingService.getRankingForBatch(anyString(), any(), anyString(), anyInt(), anyInt()))
+                .willReturn(null);
 
         // when & then
         mockMvc.perform(get("/rank")
@@ -58,7 +55,7 @@ class RankingControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
 
-        verify(rankingService).getRanking(
+        verify(rankingService).getRankingForBatch(
                 eq("day"),
                 isNull(),
                 eq("ALL"),
@@ -78,22 +75,21 @@ class RankingControllerTest {
         String dateTimeStr = "2025-12-11T14:30:00";
         LocalDateTime expectedDateTime = LocalDateTime.parse(dateTimeStr);
 
-        RankingPageResponse dummyResponse =
-                new RankingPageResponse(true, Collections.singletonList(
-                        new RankingRowResponse(
-                                1L,
-                                1,
-                                15,
-                                "홍길동",
-                                100,
-                                10L,
-                                "baekjoon123",
-                                "BACKEND_NON_FACE",
-                                0
-                        )
-                ));
+        RankingRowExtendedResponse row = new RankingRowExtendedResponse(
+                1L,
+                "박준희",
+                15,
+                245,
+                12,
+                "gr2147",
+                "BACKEND_NON_FACE",
+                true
+        );
 
-        given(rankingService.getRanking(anyString(), any(), anyString(), anyInt(), anyInt()))
+
+        RankingPageExtendedResponse dummyResponse = new RankingPageExtendedResponse(true, expectedDateTime, List.of(row));
+
+        given(rankingService.getRankingForBatch(anyString(), any(LocalDateTime.class), anyString(), anyInt(), anyInt()))
                 .willReturn(dummyResponse);
 
         // when & then
@@ -107,7 +103,7 @@ class RankingControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
 
-        verify(rankingService).getRanking(
+        verify(rankingService).getRankingForBatch(
                 eq(period),
                 eq(expectedDateTime),
                 eq(group),

--- a/src/test/java/com/project/controller/RankingControllerTest.java
+++ b/src/test/java/com/project/controller/RankingControllerTest.java
@@ -3,6 +3,7 @@ package com.project.controller;
 
 import com.project.dto.response.RankingPageExtendedResponse;
 import com.project.dto.response.RankingRowExtendedResponse;
+import com.project.dto.response.RankingRowResponse;
 import com.project.service.RankingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -75,19 +76,23 @@ class RankingControllerTest {
         String dateTimeStr = "2025-12-11T14:30:00";
         LocalDateTime expectedDateTime = LocalDateTime.parse(dateTimeStr);
 
-        RankingRowExtendedResponse row = new RankingRowExtendedResponse(
+        RankingRowResponse base = new RankingRowResponse(
                 1L,
+                1,              // rank
+                15,             // tier
                 "박준희",
-                15,
-                245,
-                12,
+                245,            // totalScore
+                12L,            // solvedCount
                 "gr2147",
                 "BACKEND_NON_FACE",
-                true
+                0               // diff
         );
 
 
-        RankingPageExtendedResponse dummyResponse = new RankingPageExtendedResponse(true, expectedDateTime, List.of(row));
+        RankingRowExtendedResponse row = RankingRowExtendedResponse.from(base, true);
+
+        RankingPageExtendedResponse dummyResponse =
+                new RankingPageExtendedResponse(true, expectedDateTime, List.of(row));
 
         given(rankingService.getRankingForBatch(anyString(), any(LocalDateTime.class), anyString(), anyInt(), anyInt()))
                 .willReturn(dummyResponse);

--- a/src/test/java/com/project/service/RankingServiceTest.java
+++ b/src/test/java/com/project/service/RankingServiceTest.java
@@ -4,7 +4,9 @@ import com.project.common.exception.BusinessException;
 import com.project.common.exception.ErrorCode;
 import com.project.dto.response.RankingPageResponse;
 import com.project.dto.response.RankingRowResponse;
+import com.project.repository.BatchMetaRepository;
 import com.project.repository.RankingQueryRepository;
+import com.project.repository.UserMetaQueryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,12 @@ class RankingServiceTest {
     @Mock
     private RankingQueryRepository rankingQueryRepository;
 
+    @Mock
+    BatchMetaRepository batchMetaRepository;
+
+    @Mock
+    UserMetaQueryRepository userMetaQueryRepository;
+
     @InjectMocks
     private RankingService rankingService;
 
@@ -47,7 +55,11 @@ class RankingServiceTest {
                 Instant.parse("2025-12-12T15:48:00Z"),
                 ZoneId.of("Asia/Seoul")
         );
-        rankingService = new RankingService(rankingQueryRepository, fixedClock);
+        rankingService = new RankingService(
+                rankingQueryRepository,
+                fixedClock,
+                batchMetaRepository,
+                userMetaQueryRepository);
     }
 
     @Test
@@ -250,5 +262,7 @@ class RankingServiceTest {
 
         verify(rankingQueryRepository, times(2)).getRankingRows(any(), any(), isNull());
     }
+
+
 
 }


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- #70 

---

## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
1. 버그
 기존 집계 마감 시간을 사용자의 요청 시간으로 조회 -> 배치가 돌아가는 시점에 사용자 요청 시 순위 계산이 0으로 처리되는 버그
집계 마감 시간을 배치 메타 테이블의 최근 스냅삿 시점으로 조회하여 배치가 돌아가는 시점에도 이전 시간대로 조회하도록 수정

2. 신규 기능
신규 유저는 create_at 컬럼에서 조회하여 3일 동안 화면에서 표시하는 기능 추가
배치 시간대에 맞춰 업데이트 시간을 표시하도록 DTO 구조 변경

3. 테스트 코드
변경 점에 따른 테스트 코드 작성

---

## ⌨ 기타
기존 DTO를 다른 도메인에 사용중이라 새로운 DTO와 서비스 함수를 만들어서 작성
추후 기존버전 삭제 예정 